### PR TITLE
MODINREACH-44 Create a Data Model to Store a Mapping of FOLIO Material Types to INN-Reach Central Item Types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <folio-spring-base.version>1.0.5</folio-spring-base.version>
-    <openapi-generator.version>4.3.1</openapi-generator.version>
+    <openapi-generator.version>5.1.0</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/inn-reach.yaml</openapi.input.file>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <testcontainers.version>1.15.1</testcontainers.version>

--- a/src/main/java/org/folio/innreach/domain/entity/MaterialTypeMapping.java
+++ b/src/main/java/org/folio/innreach/domain/entity/MaterialTypeMapping.java
@@ -1,0 +1,39 @@
+package org.folio.innreach.domain.entity;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import org.folio.innreach.domain.entity.base.Auditable;
+
+@Getter
+@Setter
+@EqualsAndHashCode(of = {"centralItemType", "materialTypeId"}, callSuper = false)
+@ToString(exclude = {"centralServer"}, callSuper = true)
+@Entity
+@Table(name = "material_type_mapping")
+public class MaterialTypeMapping extends Auditable<String> {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private UUID id;
+  private UUID materialTypeId;
+  private int centralItemType;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "central_server_id")
+  private CentralServer centralServer;
+
+}

--- a/src/main/java/org/folio/innreach/repository/MaterialTypeMappingRepository.java
+++ b/src/main/java/org/folio/innreach/repository/MaterialTypeMappingRepository.java
@@ -1,0 +1,12 @@
+package org.folio.innreach.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import org.folio.innreach.domain.entity.MaterialTypeMapping;
+
+@Repository
+public interface MaterialTypeMappingRepository extends JpaRepository<MaterialTypeMapping, UUID> {
+}

--- a/src/main/resources/db/changelog/changes/v1.0.0/2021-05-28-MODINREACH-44.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/2021-05-28-MODINREACH-44.xml
@@ -4,8 +4,8 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
-    <include file="2021-04-14-MODINREACH-9.xml" relativeToChangelogFile="true"/>
-    <include file="2021-04-27-MODINREACH-34.xml" relativeToChangelogFile="true"/>
-    <include file="2021-05-13-MODINREACH-17.xml" relativeToChangelogFile="true"/>
-    <include file="2021-05-28-MODINREACH-44.xml" relativeToChangelogFile="true"/>
+  <changeSet id="2021-05-28-01__create_mtype_mapping_table" author="dmtkachenko">
+    <sqlFile path="sql/2021-05-28-01__create-material-type-mapping-table.sql" relativeToChangelogFile="true"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/2021-05-28-01__create-material-type-mapping-table.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/2021-05-28-01__create-material-type-mapping-table.sql
@@ -1,0 +1,15 @@
+CREATE TABLE material_type_mapping
+(
+    id                 UUID         NOT NULL,
+    material_type_id   UUID         NOT NULL,
+    central_item_type  INTEGER      NOT NULL,
+    central_server_id  UUID         NOT NULL,
+    created_by         VARCHAR(255) NOT NULL,
+    created_date       TIMESTAMP    NOT NULL,
+    last_modified_by   VARCHAR(255),
+    last_modified_date TIMESTAMP,
+    CONSTRAINT pk_material_type_mapping PRIMARY KEY (id),
+    CONSTRAINT unq_mtype_mapping_server_mtype UNIQUE (central_server_id, material_type_id),
+    CONSTRAINT fk_mtype_mapping_central_server FOREIGN KEY (central_server_id)
+        REFERENCES central_server (id)
+);

--- a/src/test/java/org/folio/innreach/fixture/MaterialTypeMappingFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/MaterialTypeMappingFixture.java
@@ -1,0 +1,37 @@
+package org.folio.innreach.fixture;
+
+import static org.jeasy.random.FieldPredicates.named;
+
+import java.time.OffsetDateTime;
+
+import lombok.experimental.UtilityClass;
+import org.jeasy.random.EasyRandom;
+import org.jeasy.random.EasyRandomParameters;
+import org.jeasy.random.randomizers.range.IntegerRangeRandomizer;
+
+import org.folio.innreach.domain.entity.MaterialTypeMapping;
+
+@UtilityClass
+public class MaterialTypeMappingFixture {
+
+  private static final EasyRandom mtypeRandom;
+
+  static {
+    EasyRandomParameters params = new EasyRandomParameters()
+        .randomize(named("centralItemType"),new IntegerRangeRandomizer(0, 256))
+        .randomize(named("createdBy"), () -> "admin")
+        .randomize(named("createdDate"), OffsetDateTime::now)
+        .excludeField(named("id"))
+        .excludeField(named("centralServer"))
+        .excludeField(named("lastModifiedBy"))
+        .excludeField(named("lastModifiedDate"))
+        .excludeField(named("metadata"));
+
+    mtypeRandom = new EasyRandom(params);
+  }
+
+  public static MaterialTypeMapping createMaterialTypeMapping() {
+    return mtypeRandom.nextObject(MaterialTypeMapping.class);
+  }
+
+}

--- a/src/test/java/org/folio/innreach/repository/MaterialTypeMappingRepositoryTest.java
+++ b/src/test/java/org/folio/innreach/repository/MaterialTypeMappingRepositoryTest.java
@@ -1,13 +1,29 @@
 package org.folio.innreach.repository;
 
+import static java.util.UUID.fromString;
+import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static org.folio.innreach.fixture.MaterialTypeMappingFixture.createMaterialTypeMapping;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
+import org.apache.commons.lang3.RandomUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.test.context.jdbc.Sql;
+
+import org.folio.innreach.domain.entity.CentralServer;
+import org.folio.innreach.domain.entity.MaterialTypeMapping;
 
 @Sql(scripts = "classpath:db/central-server/pre-populate-central-server.sql")
 @Sql(scripts = "classpath:db/mtype-mapping/pre-populate-material-type-mapping.sql")
@@ -16,6 +32,8 @@ class MaterialTypeMappingRepositoryTest extends BaseRepositoryTest {
   private static final String PRE_POPULATED_MAPPING1_ID = "71bd0beb-28cb-40bb-9f40-87463d61a553";
   private static final String PRE_POPULATED_MAPPING2_ID = "d9985d0d-b121-4ccd-ac16-5ebd0ccccf7f";
   private static final String PRE_POPULATED_MAPPING3_ID = "57fad69e-8c91-48c0-a61f-a6122f52737a";
+  private static final String PRE_POPULATED_USER = "admin";
+  private static final UUID PRE_POPULATED_CENTRAL_SERVER_UUID = fromString("edab6baf-c696-42b1-89bb-1bbb8759b0d2");
 
   @Autowired
   private MaterialTypeMappingRepository repository;
@@ -31,6 +49,93 @@ class MaterialTypeMappingRepositoryTest extends BaseRepositoryTest {
         .collect(toList());
 
     assertEquals(ids, List.of(PRE_POPULATED_MAPPING1_ID, PRE_POPULATED_MAPPING2_ID, PRE_POPULATED_MAPPING3_ID));
+  }
+
+  @Test
+  void shouldGetMappingWithMetadata() {
+    var mapping = repository.getOne(fromString(PRE_POPULATED_MAPPING1_ID));
+
+    assertEquals(PRE_POPULATED_USER, mapping.getCreatedBy());
+    assertNotNull(mapping.getCreatedDate());
+    assertEquals(PRE_POPULATED_USER, mapping.getLastModifiedBy());
+    assertNotNull(mapping.getLastModifiedDate());
+  }
+
+  @Test
+  void shouldSaveNewMapping() {
+    var newLocation = createMaterialTypeMapping();
+    newLocation.setCentralServer(prepopulatedCentralServer());
+
+    var saved = repository.saveAndFlush(newLocation);
+
+    MaterialTypeMapping found = repository.getOne(saved.getId());
+    assertEquals(saved, found);
+  }
+
+  @Test
+  void shouldUpdateMaterialTypeIdAndItemType() {
+    var mapping = repository.getOne(fromString(PRE_POPULATED_MAPPING1_ID));
+
+    UUID newMaterialTypeId = randomUUID();
+    int newCentralItemType = RandomUtils.nextInt(0, 256);
+    mapping.setMaterialTypeId(newMaterialTypeId);
+    mapping.setCentralItemType(newCentralItemType);
+
+    repository.saveAndFlush(mapping);
+
+    var saved = repository.getOne(mapping.getId());
+
+    assertEquals(newMaterialTypeId, saved.getMaterialTypeId());
+    assertEquals(newCentralItemType, saved.getCentralItemType());
+  }
+
+  @Test
+  void shouldDeleteExistingMapping() {
+    UUID id = fromString(PRE_POPULATED_MAPPING1_ID);
+
+    repository.deleteById(id);
+
+    Optional<MaterialTypeMapping> deleted = repository.findById(id);
+    assertTrue(deleted.isEmpty());
+  }
+
+  @Test
+  void throwExceptionWhenSavingWithoutMaterialTypeId() {
+    var mapping = createMaterialTypeMapping();
+    mapping.setMaterialTypeId(null);
+    mapping.setCentralServer(prepopulatedCentralServer());
+
+    assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(mapping));
+  }
+
+  @Test
+  void throwExceptionWhenSavingWithInvalidCentralServerReference() {
+    var mapping = createMaterialTypeMapping();
+
+    var centralServer = new CentralServer();
+    centralServer.setId(randomUUID());
+    mapping.setCentralServer(centralServer);
+
+    var ex = assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(mapping));
+    assertThat(ex.getMessage(), containsString("constraint [fk_mtype_mapping_central_server]"));
+  }
+
+  @Test
+  void throwExceptionWhenNewMaterialTypeIdMappingExistsForTheServer() {
+    var existing = repository.getOne(fromString(PRE_POPULATED_MAPPING1_ID));
+
+    var mapping = createMaterialTypeMapping();
+    mapping.setMaterialTypeId(existing.getMaterialTypeId());
+    mapping.setCentralServer(existing.getCentralServer());
+    
+    var ex = assertThrows(DataIntegrityViolationException.class, () -> repository.saveAndFlush(mapping));
+    assertThat(ex.getMessage(), containsString("constraint [unq_mtype_mapping_server_mtype]"));
+  }
+
+  private static CentralServer prepopulatedCentralServer() {
+    var centralServer = new CentralServer();
+    centralServer.setId(PRE_POPULATED_CENTRAL_SERVER_UUID);
+    return centralServer;
   }
 
 }

--- a/src/test/java/org/folio/innreach/repository/MaterialTypeMappingRepositoryTest.java
+++ b/src/test/java/org/folio/innreach/repository/MaterialTypeMappingRepositoryTest.java
@@ -1,0 +1,36 @@
+package org.folio.innreach.repository;
+
+import static java.util.stream.Collectors.toList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
+
+@Sql(scripts = "classpath:db/central-server/pre-populate-central-server.sql")
+@Sql(scripts = "classpath:db/mtype-mapping/pre-populate-material-type-mapping.sql")
+class MaterialTypeMappingRepositoryTest extends BaseRepositoryTest {
+
+  private static final String PRE_POPULATED_MAPPING1_ID = "71bd0beb-28cb-40bb-9f40-87463d61a553";
+  private static final String PRE_POPULATED_MAPPING2_ID = "d9985d0d-b121-4ccd-ac16-5ebd0ccccf7f";
+  private static final String PRE_POPULATED_MAPPING3_ID = "57fad69e-8c91-48c0-a61f-a6122f52737a";
+
+  @Autowired
+  private MaterialTypeMappingRepository repository;
+
+  @Test
+  void shouldFindAllExistingMappings() {
+    var mappings = repository.findAll();
+
+    assertEquals(3, mappings.size());
+
+    List<String> ids = mappings.stream()
+        .map(mapping -> mapping.getId().toString())
+        .collect(toList());
+
+    assertEquals(ids, List.of(PRE_POPULATED_MAPPING1_ID, PRE_POPULATED_MAPPING2_ID, PRE_POPULATED_MAPPING3_ID));
+  }
+
+}

--- a/src/test/resources/db/mtype-mapping/pre-populate-material-type-mapping.sql
+++ b/src/test/resources/db/mtype-mapping/pre-populate-material-type-mapping.sql
@@ -1,0 +1,9 @@
+INSERT INTO material_type_mapping (
+        id, material_type_id, central_item_type, central_server_id,
+        created_by, created_date, last_modified_by, last_modified_date)
+VALUES ('71bd0beb-28cb-40bb-9f40-87463d61a553', '1a54b431-2e4f-452d-9cae-9cee66c9a892', 0, 'edab6baf-c696-42b1-89bb-1bbb8759b0d2',
+        'admin', CURRENT_TIMESTAMP, 'admin', CURRENT_TIMESTAMP),
+       ('d9985d0d-b121-4ccd-ac16-5ebd0ccccf7f', '5ee11d91-f7e8-481d-b079-65d708582ccc', 1, 'edab6baf-c696-42b1-89bb-1bbb8759b0d2',
+        'admin', CURRENT_TIMESTAMP, 'admin', CURRENT_TIMESTAMP),
+       ('57fad69e-8c91-48c0-a61f-a6122f52737a', '615b8413-82d5-4203-aa6e-e37984cb5ac3', 2, 'edab6baf-c696-42b1-89bb-1bbb8759b0d2',
+        'admin', CURRENT_TIMESTAMP, 'admin', CURRENT_TIMESTAMP);


### PR DESCRIPTION
## Purpose
Implement data model to store mapping between Folio defined material types and item types from central server

JIRA: [MODINREACH-44](https://issues.folio.org/browse/MODINREACH-44)

## Approach
- create mapping entity `MaterialTypeMapping` and defined the appropriate repository
- add liquibase scripts to create the necessary objects in DB
- verify new model with a repository test

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
