### PR TITLE
MODINREACH-44 Rollback OpenAPI generator version to 4.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <folio-spring-base.version>1.0.5</folio-spring-base.version>
-    <openapi-generator.version>5.1.0</openapi-generator.version>
+    <openapi-generator.version>4.3.1</openapi-generator.version>
     <openapi.input.file>${project.basedir}/src/main/resources/swagger.api/inn-reach.yaml</openapi.input.file>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <testcontainers.version>1.15.1</testcontainers.version>


### PR DESCRIPTION
## Purpose
There is an issue with generating Java classes from OpenApi spec with new version (5.1.0) of `openapi-generator-maven-plugin`. It only happens on Windows but not Unix systems. Have to rollback to previous working version, which is 4.3.1, as temporary solution.

## Learning
Generation fails with:
![image](https://user-images.githubusercontent.com/42244720/120459468-e63eef80-c3a0-11eb-873b-b064953d5bfb.png)
