### PR TITLE
MODINREACH-65 Create CRUD API to store a Mapping of INN-Reach Agencies to FOLIO locations

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -155,12 +155,12 @@
         {
           "methods": ["GET"],
           "pathPattern": "/inn-reach/central-servers/{centralServerId}/agency-mappings",
-          "permissionsRequired": ["inn-reach.agency-mappings.collection.get"]
+          "permissionsRequired": ["inn-reach.agency-mappings.item.get"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/inn-reach/central-servers/{centralServerId}/agency-mappings",
-          "permissionsRequired": ["inn-reach.agency-mappings.collection.put"]
+          "permissionsRequired": ["inn-reach.agency-mappings.item.put"]
         }
       ]
     },
@@ -413,22 +413,22 @@
       ]
     },
     {
-      "permissionName" : "inn-reach.agency-mappings.collection.get",
-      "displayName" : "get a collection of inn reach agency mapping entries",
-      "description" : "Get a collection of inn reach agency mapping entries"
+      "permissionName" : "inn-reach.agency-mappings.item.get",
+      "displayName" : "get INN-Reach Agency to FOLIO locations mapping",
+      "description" : "Get INN-Reach Agency to FOLIO locations mapping"
     },
     {
-      "permissionName" : "inn-reach.agency-mappings.collection.put",
-      "displayName" : "update a collection of inn reach agency mapping entries",
-      "description" : "Update a collection of inn reach agency mapping entries"
+      "permissionName" : "inn-reach.agency-mappings.item.put",
+      "displayName" : "update INN-Reach Agency to FOLIO locations mapping",
+      "description" : "Update INN-Reach Agency to FOLIO locations mapping"
     },
     {
       "permissionName" : "inn-reach.agency-mappings.all",
       "displayName" : "inn reach API module - all permissions of agency mappings",
       "description" : "All permissions of inn reach agency mappings scope",
       "subPermissions" : [
-        "inn-reach.agency-mappings.collection.get",
-        "inn-reach.agency-mappings.collection.put"
+        "inn-reach.agency-mappings.item.get",
+        "inn-reach.agency-mappings.item.put"
       ]
     },
     {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -151,6 +151,16 @@
           "methods": ["PUT"],
           "pathPattern": "/inn-reach/central-servers/{centralServerId}/item-contribution-options",
           "permissionsRequired": ["inn-reach.central-servers.item-contribution-options-configuration.item.put"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/inn-reach/central-servers/{centralServerId}/agency-mappings",
+          "permissionsRequired": ["inn-reach.agency-mappings.collection.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/inn-reach/central-servers/{centralServerId}/agency-mappings",
+          "permissionsRequired": ["inn-reach.agency-mappings.collection.put"]
         }
       ]
     },
@@ -403,6 +413,25 @@
       ]
     },
     {
+      "permissionName" : "inn-reach.agency-mappings.collection.get",
+      "displayName" : "get a collection of inn reach agency mapping entries",
+      "description" : "Get a collection of inn reach agency mapping entries"
+    },
+    {
+      "permissionName" : "inn-reach.agency-mappings.collection.put",
+      "displayName" : "update a collection of inn reach agency mapping entries",
+      "description" : "Update a collection of inn reach agency mapping entries"
+    },
+    {
+      "permissionName" : "inn-reach.agency-mappings.all",
+      "displayName" : "inn reach API module - all permissions of agency mappings",
+      "description" : "All permissions of inn reach agency mappings scope",
+      "subPermissions" : [
+        "inn-reach.agency-mappings.collection.get",
+        "inn-reach.agency-mappings.collection.put"
+      ]
+    },
+    {
       "permissionName" : "inn-reach.all",
       "displayName" : "inn reach API module - all permissions",
       "description" : "All permissions for inn reach",
@@ -415,7 +444,8 @@
         "inn-reach.location-mappings.all",
         "inn-reach.d2r.settings.any.get",
         "inn-reach.authentication.all",
-        "inn-reach.central-servers.item-contribution-options-configuration.all"
+        "inn-reach.central-servers.item-contribution-options-configuration.all",
+        "inn-reach.agency-mappings.all"
       ]
     }
   ],

--- a/src/main/java/org/folio/innreach/controller/AgencyMappingController.java
+++ b/src/main/java/org/folio/innreach/controller/AgencyMappingController.java
@@ -1,0 +1,45 @@
+package org.folio.innreach.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.innreach.domain.service.AgencyMappingService;
+import org.folio.innreach.dto.AgencyLocationMappingDTO;
+import org.folio.innreach.rest.resource.AgencyMappingsApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@Validated
+@RequestMapping("/inn-reach/central-servers")
+public class AgencyMappingController implements AgencyMappingsApi {
+
+  @Autowired
+  private AgencyMappingService service;
+
+  @Override
+  @GetMapping("/{centralServerId}/agency-mappings")
+  public ResponseEntity<AgencyLocationMappingDTO> getAgencyMappingsByServerId(@PathVariable UUID centralServerId) {
+    var mapping = service.getMapping(centralServerId);
+
+    return ResponseEntity.ok(mapping);
+  }
+
+  @Override
+  @PutMapping("/{centralServerId}/agency-mappings")
+  public ResponseEntity<Void> putAgencyMappings(@PathVariable UUID centralServerId,
+                                                AgencyLocationMappingDTO mapping) {
+
+    service.updateMapping(centralServerId, mapping);
+
+    return ResponseEntity.noContent().build();
+  }
+
+}

--- a/src/main/java/org/folio/innreach/domain/entity/AgencyLocationLscMapping.java
+++ b/src/main/java/org/folio/innreach/domain/entity/AgencyLocationLscMapping.java
@@ -19,6 +19,8 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
+import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 
@@ -48,10 +50,24 @@ public class AgencyLocationLscMapping extends Auditable<String> implements Ident
     mappedBy = "localServerMapping"
   )
   @OrderBy("agencyCode")
-  private Set<AgencyLocationAcMapping> agencyCodeMappings;
+  private Set<AgencyLocationAcMapping> agencyCodeMappings = new LinkedHashSet<>();
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "central_server_mapping_id", nullable = false, updatable = false)
   private AgencyLocationMapping centralServerMapping;
+
+  public void addAgencyCodeMapping(AgencyLocationAcMapping mapping) {
+    Objects.requireNonNull(mapping);
+
+    mapping.setLocalServerMapping(this);
+
+    agencyCodeMappings.add(mapping);
+  }
+
+  public void removeAgencyCodeMapping(AgencyLocationAcMapping mapping) {
+    Objects.requireNonNull(mapping);
+
+    agencyCodeMappings.remove(mapping);
+  }
 
 }

--- a/src/main/java/org/folio/innreach/domain/entity/AgencyLocationMapping.java
+++ b/src/main/java/org/folio/innreach/domain/entity/AgencyLocationMapping.java
@@ -79,4 +79,10 @@ public class AgencyLocationMapping extends Auditable<String> implements Identifi
     localServerMappings.add(mapping);
   }
 
+  public void removeLocalServerMapping(AgencyLocationLscMapping mapping) {
+    Objects.requireNonNull(mapping);
+
+    localServerMappings.remove(mapping);
+  }
+
 }

--- a/src/main/java/org/folio/innreach/domain/entity/AgencyLocationMapping.java
+++ b/src/main/java/org/folio/innreach/domain/entity/AgencyLocationMapping.java
@@ -37,7 +37,7 @@ import static org.folio.innreach.domain.entity.AgencyLocationMapping.FETCH_ONE_B
 @NamedQuery(
   name = FETCH_ONE_BY_CS_QUERY_NAME,
   query = FETCH_ONE_BY_CS_QUERY,
-  hints = @QueryHint(name = QueryHints.PASS_DISTINCT_THROUGH, value = "true")
+  hints = @QueryHint(name = QueryHints.PASS_DISTINCT_THROUGH, value = "false")
 )
 @Table(name = "agency_location_mapping")
 public class AgencyLocationMapping extends Auditable<String> implements Identifiable<UUID> {

--- a/src/main/java/org/folio/innreach/domain/service/AgencyMappingService.java
+++ b/src/main/java/org/folio/innreach/domain/service/AgencyMappingService.java
@@ -1,0 +1,13 @@
+package org.folio.innreach.domain.service;
+
+import org.folio.innreach.dto.AgencyLocationMappingDTO;
+
+import java.util.UUID;
+
+public interface AgencyMappingService {
+
+  AgencyLocationMappingDTO getMapping(UUID centralServerId);
+
+  AgencyLocationMappingDTO updateMapping(UUID centralServerId, AgencyLocationMappingDTO mapping);
+
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -52,6 +52,8 @@ public class AgencyMappingServiceImpl implements AgencyMappingService {
       .map(mergeFunc(incoming))
       .orElse(incoming);
 
+    repository.saveAndFlush(updated);
+
     return mapper.toDTO(updated);
   }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -1,0 +1,94 @@
+package org.folio.innreach.domain.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.innreach.domain.entity.AgencyLocationAcMapping;
+import org.folio.innreach.domain.entity.AgencyLocationLscMapping;
+import org.folio.innreach.domain.entity.AgencyLocationMapping;
+import org.folio.innreach.domain.exception.EntityNotFoundException;
+import org.folio.innreach.domain.service.AgencyMappingService;
+import org.folio.innreach.dto.AgencyLocationMappingDTO;
+import org.folio.innreach.mapper.AgencyLocationMappingMapper;
+import org.folio.innreach.repository.AgencyLocationMappingRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+import static org.folio.innreach.domain.service.impl.ServiceUtils.merge;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class AgencyMappingServiceImpl implements AgencyMappingService {
+
+  private static final String NOT_FOUND_MESSAGE_FMT = "Agency mapping with central server id: %s not found";
+  private static final Comparator<AgencyLocationLscMapping> LSC_COMPARATOR = Comparator.comparing(AgencyLocationLscMapping::getLocalServerCode);
+  private static final Comparator<AgencyLocationAcMapping> AC_COMPARATOR = Comparator.comparing(AgencyLocationAcMapping::getAgencyCode);
+
+  @Autowired
+  private AgencyLocationMappingRepository repository;
+
+  @Autowired
+  private AgencyLocationMappingMapper mapper;
+
+  @Override
+  public AgencyLocationMappingDTO getMapping(UUID centralServerId) {
+    return fetchOne(centralServerId)
+      .map(mapper::toDTO)
+      .orElseThrow(() -> new EntityNotFoundException(String.format(NOT_FOUND_MESSAGE_FMT, centralServerId)));
+  }
+
+  @Override
+  public AgencyLocationMappingDTO updateMapping(UUID centralServerId, AgencyLocationMappingDTO mappingDto) {
+    var incoming = mapper.toEntityWithRefs(mappingDto, centralServerId);
+
+    var updated = fetchOne(centralServerId)
+      .map(mergeFunc(incoming))
+      .orElse(incoming);
+
+    return mapper.toDTO(updated);
+  }
+
+  private Optional<AgencyLocationMapping> fetchOne(UUID centralServerId) {
+    return repository.fetchOneByCsId(centralServerId);
+  }
+
+  private Function<AgencyLocationMapping, AgencyLocationMapping> mergeFunc(AgencyLocationMapping incoming) {
+    return existing -> {
+      existing.setLibraryId(incoming.getLibraryId());
+      existing.setLocationId(incoming.getLocationId());
+
+      merge(incoming.getLocalServerMappings(), existing.getLocalServerMappings(), LSC_COMPARATOR,
+        existing::addLocalServerMapping, this::updateLscMapping, nothing());
+
+      return existing;
+    };
+  }
+
+  private void updateLscMapping(AgencyLocationLscMapping incoming, AgencyLocationLscMapping existing) {
+    existing.setLocationId(incoming.getLocationId());
+    existing.setLibraryId(incoming.getLibraryId());
+
+    Set<AgencyLocationAcMapping> agencyCodeMappings = incoming.getAgencyCodeMappings();
+    Set<AgencyLocationAcMapping> existingAgencyCodeMappings = existing.getAgencyCodeMappings();
+
+    merge(agencyCodeMappings, existingAgencyCodeMappings, AC_COMPARATOR,
+      existing::addAgencyCodeMapping, this::updateAcMapping, existing::removeAgencyCodeMapping);
+  }
+
+  private void updateAcMapping(AgencyLocationAcMapping incoming, AgencyLocationAcMapping existing) {
+    existing.setLocationId(incoming.getLocationId());
+    existing.setLibraryId(incoming.getLibraryId());
+  }
+
+  private <E> Consumer<E> nothing() {
+    return (e) -> { };
+  }
+
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -17,7 +17,6 @@ import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.folio.innreach.domain.service.impl.ServiceUtils.merge;
@@ -67,7 +66,7 @@ public class AgencyMappingServiceImpl implements AgencyMappingService {
       existing.setLocationId(incoming.getLocationId());
 
       merge(incoming.getLocalServerMappings(), existing.getLocalServerMappings(), LSC_COMPARATOR,
-        existing::addLocalServerMapping, this::updateLscMapping, nothing());
+        existing::addLocalServerMapping, this::updateLscMapping, existing::removeLocalServerMapping);
 
       return existing;
     };
@@ -87,10 +86,6 @@ public class AgencyMappingServiceImpl implements AgencyMappingService {
   private void updateAcMapping(AgencyLocationAcMapping incoming, AgencyLocationAcMapping existing) {
     existing.setLocationId(incoming.getLocationId());
     existing.setLibraryId(incoming.getLibraryId());
-  }
-
-  private <E> Consumer<E> nothing() {
-    return (e) -> { };
   }
 
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/ServiceUtils.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ServiceUtils.java
@@ -1,9 +1,10 @@
 package org.folio.innreach.domain.service.impl;
 
 import static java.util.Objects.nonNull;
-import static org.apache.commons.collections4.ListUtils.emptyIfNull;
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -79,16 +80,16 @@ class ServiceUtils {
     return repository.saveAll(toSave);
   }
 
-  static <E extends Comparable<E>> void merge(List<E> incoming, List<E> stored,
+  static <E extends Comparable<E>> void merge(Collection<E> incoming, Collection<E> stored,
       Consumer<E> addMethod, BiConsumer<E, E> updateMethod, Consumer<E> deleteMethod) {
     merge(incoming, stored, Comparable::compareTo, addMethod, updateMethod, deleteMethod);
   }
 
-  static <E> void merge(List<E> incoming, List<E> stored, Comparator<E> comparator,
+  static <E> void merge(Collection<E> incoming, Collection<E> stored, Comparator<E> comparator,
       Consumer<E> addMethod, BiConsumer<E, E> updateMethod, Consumer<E> deleteMethod) {
 
     var storedList = new ArrayList<>(emptyIfNull(stored));
-    
+
     var incomingList = new ArrayList<>(emptyIfNull(incoming));
     incomingList.sort(comparator);
 

--- a/src/main/java/org/folio/innreach/mapper/AgencyLocationMappingMapper.java
+++ b/src/main/java/org/folio/innreach/mapper/AgencyLocationMappingMapper.java
@@ -12,7 +12,6 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 
 import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;

--- a/src/main/java/org/folio/innreach/mapper/AgencyLocationMappingMapper.java
+++ b/src/main/java/org/folio/innreach/mapper/AgencyLocationMappingMapper.java
@@ -1,0 +1,76 @@
+package org.folio.innreach.mapper;
+
+import org.folio.innreach.domain.entity.AgencyLocationAcMapping;
+import org.folio.innreach.domain.entity.AgencyLocationLscMapping;
+import org.folio.innreach.domain.entity.AgencyLocationMapping;
+import org.folio.innreach.domain.entity.CentralServer;
+import org.folio.innreach.dto.AgencyLocationAcMappingDTO;
+import org.folio.innreach.dto.AgencyLocationLscMappingDTO;
+import org.folio.innreach.dto.AgencyLocationMappingDTO;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+
+import static org.apache.commons.collections4.CollectionUtils.emptyIfNull;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, uses = DateMapper.class)
+public interface AgencyLocationMappingMapper {
+
+  @Mapping(target = "localServerMappings", source = "dto.localServers")
+  @Mapping(target = "id", source = "dto.id", ignore = true)
+  AgencyLocationMapping toEntity(AgencyLocationMappingDTO dto);
+
+  @Mapping(target = "localServers", source = "entity.localServerMappings")
+  @Mapping(target = "metadata.createdDate", source = "entity.createdDate")
+  @Mapping(target = "metadata.createdByUsername", source = "entity.createdBy")
+  @Mapping(target = "metadata.updatedDate", source = "entity.lastModifiedDate")
+  @Mapping(target = "metadata.updatedByUsername", source = "entity.lastModifiedBy")
+  AgencyLocationMappingDTO toDTO(AgencyLocationMapping entity);
+
+  @Mapping(target = "localServerCode", source = "dto.localCode")
+  @Mapping(target = "id", source = "dto.id", ignore = true)
+  AgencyLocationLscMapping toEntity(AgencyLocationLscMappingDTO dto);
+
+  Collection<AgencyLocationLscMapping> toEntities(Iterable<AgencyLocationLscMappingDTO> dtos);
+
+  @Mapping(target = "localCode", source = "entity.localServerCode")
+  @Mapping(target = "metadata.createdDate", source = "entity.createdDate")
+  @Mapping(target = "metadata.createdByUsername", source = "entity.createdBy")
+  @Mapping(target = "metadata.updatedDate", source = "entity.lastModifiedDate")
+  @Mapping(target = "metadata.updatedByUsername", source = "entity.lastModifiedBy")
+  AgencyLocationLscMappingDTO toDTO(AgencyLocationLscMapping entity);
+
+  Collection<AgencyLocationLscMappingDTO> toDTOs(Iterable<AgencyLocationLscMapping> entities);
+
+  @Mapping(target = "id", source = "dto.id", ignore = true)
+  AgencyLocationAcMapping toEntity(AgencyLocationAcMappingDTO dto);
+
+  @Mapping(target = "metadata.createdDate", source = "entity.createdDate")
+  @Mapping(target = "metadata.createdByUsername", source = "entity.createdBy")
+  @Mapping(target = "metadata.updatedDate", source = "entity.lastModifiedDate")
+  @Mapping(target = "metadata.updatedByUsername", source = "entity.lastModifiedBy")
+  AgencyLocationAcMappingDTO toDTO(AgencyLocationAcMapping entity);
+
+  default AgencyLocationMapping toEntityWithRefs(AgencyLocationMappingDTO dto, UUID centralServerId) {
+    var entity = toEntity(dto);
+
+    emptyIfNull(entity.getLocalServerMappings())
+      .forEach(lsm -> {
+        lsm.setCentralServerMapping(entity);
+
+        emptyIfNull(lsm.getAgencyCodeMappings())
+          .forEach(acm -> acm.setLocalServerMapping(lsm));
+      });
+
+    var server = new CentralServer();
+    server.setId(centralServerId);
+    entity.setCentralServer(server);
+
+    return entity;
+  }
+
+}

--- a/src/main/java/org/folio/innreach/repository/AgencyLocationMappingRepository.java
+++ b/src/main/java/org/folio/innreach/repository/AgencyLocationMappingRepository.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Repository
 public interface AgencyLocationMappingRepository extends JpaRepository<AgencyLocationMapping, UUID> {
 
-  @Query(name = AgencyLocationMapping.FETCH_ONE_BY_ID_QUERY_NAME)
-  Optional<AgencyLocationMapping> fetchOne(UUID id);
+  @Query(name = AgencyLocationMapping.FETCH_ONE_BY_CS_QUERY_NAME)
+  Optional<AgencyLocationMapping> fetchOneByCsId(UUID id);
 
 }

--- a/src/main/resources/db/changelog/changes/v1.0.0/2021-07-28-MODINREACH-65.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/2021-07-28-MODINREACH-65.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet id="2021-07-28-01__alter-agency-location-mapping-tables" author="maryna_steshenko">
+    <sqlFile path="sql/2021-07-28-01__alter-agency-location-mapping-tables.sql" relativeToChangelogFile="true"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.0/changelog-v1.0.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/changelog-v1.0.0.xml
@@ -19,4 +19,5 @@
     <include file="2021-07-21-MODINREACH-12.xml" relativeToChangelogFile="true"/>
     <include file="2021-07-21-MODINREACH-49.xml" relativeToChangelogFile="true"/>
     <include file="2021-07-22-MODINREACH-115.xml" relativeToChangelogFile="true"/>
+    <include file="2021-07-28-MODINREACH-65.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/2021-07-28-01__alter-agency-location-mapping-tables.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/2021-07-28-01__alter-agency-location-mapping-tables.sql
@@ -1,0 +1,11 @@
+ALTER TABLE agency_location_lsc_mapping
+    ALTER COLUMN library_id DROP NOT NULL;
+
+ALTER TABLE agency_location_lsc_mapping
+    ALTER COLUMN location_id DROP NOT NULL;
+
+ALTER TABLE agency_location_ac_mapping
+    ALTER COLUMN library_id DROP NOT NULL;
+
+ALTER TABLE agency_location_ac_mapping
+    ALTER COLUMN location_id DROP NOT NULL;

--- a/src/main/resources/swagger.api/inn-reach.yaml
+++ b/src/main/resources/swagger.api/inn-reach.yaml
@@ -589,6 +589,49 @@ paths:
         required: true
       parameters:
         - $ref: '#/components/parameters/centralServerId'
+  /central-servers/{centralServerId}/agency-mappings:
+    get:
+      description: Get a list of Inn-Reach Agency to FOLIO location mappings for the given central server
+      operationId: getAgencyMappingsByServerId
+      tags:
+        - agency-mappings
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/agencyLocationMappingDTO"
+        '400':
+          $ref: "#/components/responses/trait_response_malformed_query_400"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      parameters:
+        - $ref: "#/components/parameters/centralServerId"
+    put:
+      description: >-
+        Update (add) INN-Reach Agency to FOLIO location mappings
+        associated with the central server
+      operationId: putAgencyMappings
+      tags:
+        - agency-mappings
+      responses:
+        '204':
+          description: Mapping successfully updated
+        '400':
+          $ref: "#/components/responses/trait_response_validation_400"
+        '409':
+          $ref: "#/components/responses/trait_response_409"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/agencyLocationMappingDTO"
+        required: true
+      parameters:
+        - $ref: "#/components/parameters/centralServerId"
 components:
   schemas:
     UUID:
@@ -629,6 +672,8 @@ components:
       $ref: schemas/authenticationRequest.json
     itemContributionOptionsConfigurationDTO:
       $ref: schemas/itemContributionOptionsConfigurationDTO.json
+    agencyLocationMappingDTO:
+      $ref: schemas/agencyLocationMappingDTO.json
   parameters:
     id:
       name: id

--- a/src/main/resources/swagger.api/schemas/agencyLocationAcMappingDTO.json
+++ b/src/main/resources/swagger.api/schemas/agencyLocationAcMappingDTO.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "INN-Reach Agency to FOLIO location mapping",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Mapping id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "agencyCode": {
+      "description": "Agency code",
+      "type": "string",
+      "maxLength": 5
+    },
+    "locationId": {
+      "description": "Location id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "libraryId": {
+      "description": "Library id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "metadata": {
+      "description": "Entity metadata",
+      "type": "object",
+      "$ref": "metadata.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "agencyCode"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/agencyLocationLscMappingDTO.json
+++ b/src/main/resources/swagger.api/schemas/agencyLocationLscMappingDTO.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "INN-Reach Agency to FOLIO location mapping",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Mapping id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "localCode": {
+      "description": "Local server code",
+      "type": "string",
+      "maxLength": 5
+    },
+    "locationId": {
+      "description": "Location id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "libraryId": {
+      "description": "Location id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "agencyCodeMappings": {
+      "description": "Agency code mappings",
+      "type": "array",
+      "items": {
+        "$ref": "agencyLocationAcMappingDTO.json"
+      }
+    },
+    "metadata": {
+      "description": "Entity metadata",
+      "type": "object",
+      "$ref": "metadata.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "localCode"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/agencyLocationMappingDTO.json
+++ b/src/main/resources/swagger.api/schemas/agencyLocationMappingDTO.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "INN-Reach Agency to FOLIO locations mapping",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Mapping id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "locationId": {
+      "description": "Location id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "libraryId": {
+      "description": "Location id",
+      "type": "string",
+      "format": "uuid"
+    },
+    "localServers": {
+      "description": "Local server mappings",
+      "type": "array",
+      "items": {
+        "$ref": "agencyLocationLscMappingDTO.json"
+      }
+    },
+    "metadata": {
+      "description": "Entity metadata",
+      "type": "object",
+      "$ref": "metadata.json"
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "locationId",
+    "libraryId"
+  ]
+}

--- a/src/test/java/org/folio/innreach/controller/AgencyMappingControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/AgencyMappingControllerTest.java
@@ -210,6 +210,27 @@ class AgencyMappingControllerTest extends BaseControllerTest {
     "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/agency-loc-mapping/pre-populate-agency-location-mapping.sql"
   })
+  void shouldDeleteLocalServerMappings() {
+    var existing = mapper.toDTO(fetchDbEntity());
+    existing.getLocalServers().clear();
+
+    var responseEntity =
+      testRestTemplate.exchange(baseMappingURL(), HttpMethod.PUT, new HttpEntity<>(existing), Void.class);
+
+    assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+    assertFalse(responseEntity.hasBody());
+
+    var updated = mapper.toDTO(fetchDbEntity());
+    var updatedLsMappings = updated.getLocalServers();
+
+    assertTrue(updatedLsMappings.isEmpty());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/agency-loc-mapping/pre-populate-agency-location-mapping.sql"
+  })
   void shouldCreateUpdateAndDeleteMappingsAtTheSameTime() {
     var existing = mapper.toDTO(fetchDbEntity());
     var existingLsMappings = existing.getLocalServers();

--- a/src/test/java/org/folio/innreach/controller/AgencyMappingControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/AgencyMappingControllerTest.java
@@ -1,0 +1,289 @@
+package org.folio.innreach.controller;
+
+import org.assertj.core.api.Assertions;
+import org.folio.innreach.controller.base.BaseControllerTest;
+import org.folio.innreach.domain.entity.AgencyLocationMapping;
+import org.folio.innreach.dto.AgencyLocationAcMappingDTO;
+import org.folio.innreach.dto.AgencyLocationLscMappingDTO;
+import org.folio.innreach.dto.AgencyLocationMappingDTO;
+import org.folio.innreach.dto.ValidationErrorsDTO;
+import org.folio.innreach.mapper.AgencyLocationMappingMapper;
+import org.folio.innreach.repository.AgencyLocationMappingRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import static org.folio.innreach.controller.ControllerTestUtils.createValidationError;
+import static org.folio.innreach.fixture.TestUtil.deserializeFromJsonFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.samePropertyValuesAs;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+
+@Sql(
+  scripts = {
+    "classpath:db/agency-loc-mapping/clear-agency-location-mapping.sql",
+    "classpath:db/central-server/clear-central-server-tables.sql"},
+  executionPhase = AFTER_TEST_METHOD
+)
+@SqlMergeMode(MERGE)
+class AgencyMappingControllerTest extends BaseControllerTest {
+
+  private static final UUID PRE_POPULATED_CENTRAL_SERVER_ID = UUID.fromString("edab6baf-c696-42b1-89bb-1bbb8759b0d2");
+  private static final UUID PRE_POPULATED_LOCATION2_ID = UUID.fromString("2eda63ce-6b5d-45a6-8481-f83bc77c2a14");
+  private static final String PRE_POPULATED_AGENCY_CODE = "5east";
+  private static final String PRE_POPULATED_AGENCY2_CODE = "5main";
+
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+  @Autowired
+  private AgencyLocationMappingRepository repository;
+  @Autowired
+  private AgencyLocationMappingMapper mapper;
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/agency-loc-mapping/pre-populate-agency-location-mapping.sql"
+  })
+  void shouldGetExistingMappingForCentralServer() {
+    var responseEntity = testRestTemplate.getForEntity(baseMappingURL(), AgencyLocationMappingDTO.class);
+
+    assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
+    assertTrue(responseEntity.hasBody());
+
+    var response = responseEntity.getBody();
+    assertNotNull(response);
+
+    var existing = fetchDbEntity();
+
+    assertNotNull(existing);
+
+    var existingLsMappings = mapper.toDTOs(existing.getLocalServerMappings()).toArray();
+    assertThat(response.getLocalServers(), containsInAnyOrder(existingLsMappings));
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql"
+  })
+  void shouldReturn404IfNoMappingFound() {
+    var responseEntity = testRestTemplate.getForEntity(baseMappingURL(), AgencyLocationMappingDTO.class);
+
+    assertEquals(NOT_FOUND, responseEntity.getStatusCode());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql"
+  })
+  void shouldCreateNewMappings() {
+    var newMapping = deserializeMapping();
+    var newLsMappings = newMapping.getLocalServers();
+    var newAcMappings = getAllAcMappings(newLsMappings);
+
+    var responseEntity = testRestTemplate
+      .exchange(baseMappingURL(), HttpMethod.PUT, new HttpEntity<>(newMapping), Void.class);
+
+    assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+    assertFalse(responseEntity.hasBody());
+
+    var createdEntity = fetchDbEntity();
+
+    assertNotNull(createdEntity);
+
+    var created = mapper.toDTO(createdEntity);
+
+    assertThat(created, samePropertyValuesAs(newMapping, "id", "metadata", "localServers"));
+
+    Assertions.assertThat(created.getLocalServers())
+      .hasSize(newLsMappings.size())
+      .usingElementComparatorOnFields("localCode", "locationId", "libraryId")
+      .containsExactlyInAnyOrderElementsOf(newLsMappings);
+
+    Assertions.assertThat(created.getLocalServers())
+      .flatExtracting(AgencyLocationLscMappingDTO::getAgencyCodeMappings)
+      .hasSize(newAcMappings.size())
+      .usingElementComparatorOnFields("agencyCode", "locationId", "libraryId")
+      .containsExactlyInAnyOrderElementsOf(newAcMappings);
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql"
+  })
+  void return400WhenCreatingNewMappingWithNullLocationId() {
+    var newMapping = deserializeMapping();
+
+    newMapping.setLocationId(null);
+
+    var responseEntity =
+      testRestTemplate.exchange(baseMappingURL(), HttpMethod.PUT, new HttpEntity<>(newMapping), ValidationErrorsDTO.class);
+
+    assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+
+    assertNotNull(responseEntity.getBody());
+    assertThat(responseEntity.getBody().getValidationErrors(),
+      contains(createValidationError("locationId", "must not be null")));
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql"
+  })
+  void return400WhenCreatingNewMappingWithNullLocalServerCode() {
+    var newMapping = deserializeMapping();
+
+    newMapping.getLocalServers().get(0).setLocalCode(null);
+
+    var responseEntity = testRestTemplate.exchange(baseMappingURL(), HttpMethod.PUT, new HttpEntity<>(newMapping),
+      ValidationErrorsDTO.class);
+
+    assertEquals(BAD_REQUEST, responseEntity.getStatusCode());
+
+    assertNotNull(responseEntity.getBody());
+    assertThat(responseEntity.getBody().getValidationErrors(),
+      contains(createValidationError("localServers[0].localCode", "must not be null")));
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/agency-loc-mapping/pre-populate-agency-location-mapping.sql"
+  })
+  void shouldUpdateExistingMapping() {
+    var existing = mapper.toDTO(fetchDbEntity());
+
+    existing.setLocationId(PRE_POPULATED_LOCATION2_ID);
+
+    existing.getLocalServers()
+      .stream()
+      .peek(m -> m.setLocationId(PRE_POPULATED_LOCATION2_ID))
+      .flatMap(m -> m.getAgencyCodeMappings().stream())
+      .forEach(am -> am.setLocationId(PRE_POPULATED_LOCATION2_ID));
+
+    var responseEntity =
+      testRestTemplate.exchange(baseMappingURL(), HttpMethod.PUT, new HttpEntity<>(existing), Void.class);
+
+    assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+    assertFalse(responseEntity.hasBody());
+
+    var updated = mapper.toDTO(fetchDbEntity());
+    var updatedLsMappings = updated.getLocalServers();
+    var existingLsMappings = existing.getLocalServers();
+
+    assertEquals(existing.getLocationId(), updated.getLocationId());
+
+    Assertions.assertThat(updatedLsMappings)
+      .extracting(AgencyLocationLscMappingDTO::getLocationId)
+      .hasSize(existingLsMappings.size())
+      .containsOnly(PRE_POPULATED_LOCATION2_ID);
+
+    Assertions.assertThat(updatedLsMappings)
+      .flatExtracting(AgencyLocationLscMappingDTO::getAgencyCodeMappings)
+      .extracting(AgencyLocationAcMappingDTO::getLocationId)
+      .containsOnly(PRE_POPULATED_LOCATION2_ID);
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/agency-loc-mapping/pre-populate-agency-location-mapping.sql"
+  })
+  void shouldCreateUpdateAndDeleteMappingsAtTheSameTime() {
+    var existing = mapper.toDTO(fetchDbEntity());
+    var existingLsMappings = existing.getLocalServers();
+    var existingLsMapping = existingLsMappings.get(0);
+
+    // to delete
+    existingLsMapping
+      .getAgencyCodeMappings()
+      .removeIf(agencyCodeEquals(PRE_POPULATED_AGENCY_CODE));
+
+    // to update
+    existingLsMapping.setLocationId(PRE_POPULATED_LOCATION2_ID);
+
+    findInCollection(existingLsMapping.getAgencyCodeMappings(), agencyCodeEquals(PRE_POPULATED_AGENCY2_CODE))
+      .ifPresent(am -> am.setLocationId(PRE_POPULATED_LOCATION2_ID));
+
+    // to insert
+    var newMapping = deserializeMapping();
+    existingLsMappings.addAll(newMapping.getLocalServers());
+
+    var responseEntity =
+      testRestTemplate.exchange(baseMappingURL(), HttpMethod.PUT, new HttpEntity<>(existing), Void.class);
+
+    assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+    assertFalse(responseEntity.hasBody());
+
+    var updated = mapper.toDTO(fetchDbEntity());
+    var updatedLsMappings = updated.getLocalServers();
+
+    // verify changes
+    Assertions.assertThat(updatedLsMappings)
+      .hasSize(existingLsMappings.size())
+      .usingElementComparatorOnFields("localCode", "locationId", "libraryId")
+      .containsExactlyInAnyOrderElementsOf(existingLsMappings);
+
+    var existingAcMappings = getAllAcMappings(existingLsMappings);
+
+    Assertions.assertThat(updatedLsMappings)
+      .flatExtracting(AgencyLocationLscMappingDTO::getAgencyCodeMappings)
+      .hasSize(existingAcMappings.size())
+      .usingElementComparatorOnFields("agencyCode", "locationId", "libraryId")
+      .containsExactlyInAnyOrderElementsOf(existingAcMappings);
+  }
+
+  private static String baseMappingURL() {
+    return baseMappingURL(PRE_POPULATED_CENTRAL_SERVER_ID.toString());
+  }
+
+  private static String baseMappingURL(String serverId) {
+    return "/inn-reach/central-servers/" + serverId + "/agency-mappings";
+  }
+
+  private AgencyLocationMappingDTO deserializeMapping() {
+    return deserializeFromJsonFile(
+      "/agency-mapping/create-agency-mappings-request.json", AgencyLocationMappingDTO.class);
+  }
+
+  private AgencyLocationMapping fetchDbEntity() {
+    return repository.fetchOneByCsId(PRE_POPULATED_CENTRAL_SERVER_ID).orElse(null);
+  }
+
+  private Predicate<AgencyLocationAcMappingDTO> agencyCodeEquals(String agencyCode) {
+    return m -> agencyCode.equals(m.getAgencyCode());
+  }
+
+  private List<AgencyLocationAcMappingDTO> getAllAcMappings(List<AgencyLocationLscMappingDTO> lsMappings) {
+    return lsMappings
+      .stream()
+      .flatMap(m -> m.getAgencyCodeMappings().stream())
+      .collect(Collectors.toList());
+  }
+
+  private static <T> Optional<T> findInCollection(Collection<T> mappings, Predicate<T> filter) {
+    return mappings.stream().filter(filter).findFirst();
+  }
+
+}

--- a/src/test/java/org/folio/innreach/repository/AgencyLocationMappingRepositoryTest.java
+++ b/src/test/java/org/folio/innreach/repository/AgencyLocationMappingRepositoryTest.java
@@ -32,6 +32,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class AgencyLocationMappingRepositoryTest extends BaseRepositoryTest {
 
   private static final String PRE_POPULATED_MAPPING_ID = "b8d3f619-6a7c-41c3-9a99-bb937735dcc7";
+  private static final String PRE_POPULATED_CS_ID = "edab6baf-c696-42b1-89bb-1bbb8759b0d2";
 
   private static final UUID PRE_POPULATED_LOCATION_UUID = fromString("99b0d4e2-a5ec-46a1-a5ea-1080e609f969");
   private static final UUID PRE_POPULATED_LIBRARY_UUID = fromString("70cf3473-77f2-4f5c-92c3-6489e65769e4");
@@ -58,7 +59,7 @@ class AgencyLocationMappingRepositoryTest extends BaseRepositoryTest {
 
   @Test
   void shouldFetchExistingMapping() {
-    var mapping = repository.fetchOne(fromString(PRE_POPULATED_MAPPING_ID)).get();
+    var mapping = repository.fetchOneByCsId(fromString(PRE_POPULATED_CS_ID)).get();
 
     assertEquals(PRE_POPULATED_LIBRARY_UUID, mapping.getLibraryId());
     assertEquals(PRE_POPULATED_LOCATION_UUID, mapping.getLocationId());

--- a/src/test/resources/json/agency-mapping/create-agency-mappings-request.json
+++ b/src/test/resources/json/agency-mapping/create-agency-mappings-request.json
@@ -1,0 +1,23 @@
+{
+  "libraryId": "1a551e37-af8a-40f5-b25e-0837db791429",
+  "locationId": "ab6a8c69-ee1a-4b52-a881-dc86da6be857",
+  "localServers": [
+    {
+      "localCode": "5htxv",
+      "libraryId": "86dc48c5-9bea-4006-bb43-82f250089651",
+      "locationId": "edb00dae-2735-4e38-bd41-69427295fdbe",
+      "agencyCodeMappings": [
+        {
+          "agencyCode": "5qwer",
+          "libraryId": "c868d07c-d26f-4f32-9666-f100b069253d",
+          "locationId": "9b0317f2-8409-455c-9cb6-4fb11395d04b"
+        },
+        {
+          "agencyCode": "5zxcv",
+          "libraryId": "22dcf77c-08ef-43ac-a254-4d3f996a0de9",
+          "locationId": "8c0f7109-2f56-41ab-b2fd-7e326a9323dc"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose
To facilitate circulation transactions, mod-inn-reach must create "temporary" instance, holding, and item records for items being borrowed from other agencies not hosted on the same local server. One of the required attributes of an item record is its permanent location. Based on the needs of the local server, it should be possible to configure what FOLIO location is assigned to items borrowed from these other agencies by mapping all agencies to a single FOLIO shelving location, each local server to a single location, each agency to its own dedicated location, or some combination of these. A default location must be mapped at the central server level, and will inherit to all local servers associated with that central server and all agencies associated with those local servers, unless otherwise explicitly configured. The list of local server and their associated agencies is supplied by the INN-Reach central server and should be referenced by their local server or agency codes (five-character, lower-case alpha-numeric strings). FOLIO locations should be referenced by Id.

JIRA: [MODINREACH-65](https://issues.folio.org/browse/MODINREACH-65)
## Approach
Create CRUD API to store agency mappings

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
