### PR TITLE
MODINREACH-50 Record Contribution Settings: API to CRUD Data Model to Store Contributed MARC Transformation Options Settings for INN-Reach Central Servers

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -161,6 +161,31 @@
           "methods": ["PUT"],
           "pathPattern": "/inn-reach/central-servers/{centralServerId}/agency-mappings",
           "permissionsRequired": ["inn-reach.agency-mappings.item.put"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/inn-reach/central-servers/{centralServerId}/marc-transformation-options",
+          "permissionsRequired": ["inn-reach.central-servers.marc-transformation-options-settings.item.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/inn-reach/central-servers/marc-transformation-options",
+          "permissionsRequired": ["inn-reach.central-servers.marc-transformation-options-settings.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/inn-reach/central-servers/{centralServerId}/marc-transformation-options",
+          "permissionsRequired": ["inn-reach.central-servers.marc-transformation-options-settings.item.post"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/inn-reach/central-servers/{centralServerId}/marc-transformation-options",
+          "permissionsRequired": ["inn-reach.central-servers.marc-transformation-options-settings.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/inn-reach/central-servers/{centralServerId}/marc-transformation-options",
+          "permissionsRequired": ["inn-reach.central-servers.marc-transformation-options-settings.item.delete"]
         }
       ]
     },
@@ -432,6 +457,43 @@
       ]
     },
     {
+      "permissionName" : "inn-reach.central-servers.marc-transformation-options-settings.item.get",
+      "displayName" : "get marc transformations options settings",
+      "description" : "Get MARC Transformation Options Settings"
+    },
+    {
+      "permissionName" : "inn-reach.central-servers.marc-transformation-options-settings.collection.get",
+      "displayName" : "get a collection of marc transformations options settings",
+      "description" : "Get a collection of MARC Transformation Options Settings"
+    },
+    {
+      "permissionName" : "inn-reach.central-servers.marc-transformation-options-settings.item.post",
+      "displayName" : "create marc transformations options settings",
+      "description" : "Add MARC Transformation Options Settings"
+    },
+    {
+      "permissionName" : "inn-reach.central-servers.marc-transformation-options-settings.item.put",
+      "displayName" : "update marc transformations options settings",
+      "description" : "Update MARC Transformation Options Settings"
+    },
+    {
+      "permissionName" : "inn-reach.central-servers.marc-transformation-options-settings.item.delete",
+      "displayName" : "delete marc transformations options settings",
+      "description" : "Delete MARC Transformation Options Settings"
+    },
+    {
+      "permissionName" : "inn-reach.central-servers.marc-transformation-options-settings.all",
+      "displayName" : "inn reach API module - all permissions of marc transformations options settings",
+      "description" : "All permissions for MARC Transformation Options Settings",
+      "subPermissions" : [
+        "inn-reach.central-servers.marc-transformation-options-settings.item.get",
+        "inn-reach.central-servers.marc-transformation-options-settings.collection.get",
+        "inn-reach.central-servers.marc-transformation-options-settings.item.post",
+        "inn-reach.central-servers.marc-transformation-options-settings.item.put",
+        "inn-reach.central-servers.marc-transformation-options-settings.item.delete"
+      ]
+    },
+    {
       "permissionName" : "inn-reach.all",
       "displayName" : "inn reach API module - all permissions",
       "description" : "All permissions for inn reach",
@@ -445,7 +507,8 @@
         "inn-reach.d2r.settings.any.get",
         "inn-reach.authentication.all",
         "inn-reach.central-servers.item-contribution-options-configuration.all",
-        "inn-reach.agency-mappings.all"
+        "inn-reach.agency-mappings.all",
+        "inn-reach.central-servers.marc-transformation-options-settings.all"
       ]
     }
   ],

--- a/src/main/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsController.java
+++ b/src/main/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsController.java
@@ -1,0 +1,47 @@
+package org.folio.innreach.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.innreach.domain.service.MARCTransformationOptionsSettingsService;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.folio.innreach.rest.resource.MARCTransformationOptionsSettingsApi;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/inn-reach/central-servers/{centralServerId}/marc-transformation-options")
+public class MARCTransformationOptionsSettingsController implements MARCTransformationOptionsSettingsApi {
+  @Autowired
+  private final MARCTransformationOptionsSettingsService service;
+
+  @Override
+  @GetMapping
+  public ResponseEntity<MARCTransformationOptionsSettingsDTO> getMARCTransformationOptionsSettingsById(@PathVariable UUID centralServerId){
+    var marcTransformOptSet = service.getMARCTransformOptSet(centralServerId);
+    return ResponseEntity.ok(marcTransformOptSet);
+  }
+
+  @Override
+  @PostMapping
+  public ResponseEntity<MARCTransformationOptionsSettingsDTO> createMARCTransformationOptionsSettings(@PathVariable UUID centralServerId, @Valid MARCTransformationOptionsSettingsDTO dto){
+    var createdMARCTransformOptSet = service.createMARCTransformOptSet(centralServerId, dto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(createdMARCTransformOptSet);
+  }
+
+  @Override
+  @PutMapping
+  public ResponseEntity<Void> updateMARCTransformationOptionsSettings(@PathVariable UUID centralServerId, @Valid MARCTransformationOptionsSettingsDTO dto){
+    service.updateMARCTransformOptSet(centralServerId, dto);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/src/main/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsController.java
+++ b/src/main/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsController.java
@@ -32,35 +32,35 @@ public class MARCTransformationOptionsSettingsController implements MARCTransfor
   @GetMapping("/marc-transformation-options")
   public ResponseEntity<MARCTransformationOptionsSettingsListDTO> getAllMARCTransformationOptionsSettings(@Min(0) @Max(2147483647) @Valid Integer offset,
                                                                                                           @Min(0) @Max(2147483647) @Valid Integer limit){
-    var marcTransformOptSetList = service.getAllMARCTransformOptSet(offset, limit);
+    var marcTransformOptSetList = service.getAll(offset, limit);
     return ResponseEntity.ok(marcTransformOptSetList);
   }
 
   @Override
   @GetMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<MARCTransformationOptionsSettingsDTO> getMARCTransformationOptionsSettingsById(@PathVariable UUID centralServerId){
-    var marcTransformOptSet = service.getMARCTransformOptSet(centralServerId);
+    var marcTransformOptSet = service.get(centralServerId);
     return ResponseEntity.ok(marcTransformOptSet);
   }
 
   @Override
   @PostMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<MARCTransformationOptionsSettingsDTO> createMARCTransformationOptionsSettings(@PathVariable UUID centralServerId, @Valid MARCTransformationOptionsSettingsDTO dto){
-    var createdMARCTransformOptSet = service.createMARCTransformOptSet(centralServerId, dto);
+    var createdMARCTransformOptSet = service.create(centralServerId, dto);
     return ResponseEntity.status(HttpStatus.CREATED).body(createdMARCTransformOptSet);
   }
 
   @Override
   @PutMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<Void> updateMARCTransformationOptionsSettings(@PathVariable UUID centralServerId, @Valid MARCTransformationOptionsSettingsDTO dto){
-    service.updateMARCTransformOptSet(centralServerId, dto);
+    service.update(centralServerId, dto);
     return ResponseEntity.noContent().build();
   }
 
   @Override
   @DeleteMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<Void> deleteMARCTransformationOptionsSettings (@PathVariable UUID centralServerId) {
-    service.deleteMARCTransformOptSet(centralServerId);
+    service.delete(centralServerId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsController.java
+++ b/src/main/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsController.java
@@ -3,10 +3,12 @@ package org.folio.innreach.controller;
 import lombok.RequiredArgsConstructor;
 import org.folio.innreach.domain.service.MARCTransformationOptionsSettingsService;
 import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsListDTO;
 import org.folio.innreach.rest.resource.MARCTransformationOptionsSettingsApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -15,33 +17,50 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
 import java.util.UUID;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/inn-reach/central-servers/{centralServerId}/marc-transformation-options")
+@RequestMapping("/inn-reach/central-servers")
 public class MARCTransformationOptionsSettingsController implements MARCTransformationOptionsSettingsApi {
   @Autowired
   private final MARCTransformationOptionsSettingsService service;
 
   @Override
-  @GetMapping
+  @GetMapping("/marc-transformation-options")
+  public ResponseEntity<MARCTransformationOptionsSettingsListDTO> getAllMARCTransformationOptionsSettings(@Min(0) @Max(2147483647) @Valid Integer offset,
+                                                                                                          @Min(0) @Max(2147483647) @Valid Integer limit){
+    var marcTransformOptSetList = service.getAllMARCTransformOptSet(offset, limit);
+    return ResponseEntity.ok(marcTransformOptSetList);
+  }
+
+  @Override
+  @GetMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<MARCTransformationOptionsSettingsDTO> getMARCTransformationOptionsSettingsById(@PathVariable UUID centralServerId){
     var marcTransformOptSet = service.getMARCTransformOptSet(centralServerId);
     return ResponseEntity.ok(marcTransformOptSet);
   }
 
   @Override
-  @PostMapping
+  @PostMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<MARCTransformationOptionsSettingsDTO> createMARCTransformationOptionsSettings(@PathVariable UUID centralServerId, @Valid MARCTransformationOptionsSettingsDTO dto){
     var createdMARCTransformOptSet = service.createMARCTransformOptSet(centralServerId, dto);
     return ResponseEntity.status(HttpStatus.CREATED).body(createdMARCTransformOptSet);
   }
 
   @Override
-  @PutMapping
+  @PutMapping("/{centralServerId}/marc-transformation-options")
   public ResponseEntity<Void> updateMARCTransformationOptionsSettings(@PathVariable UUID centralServerId, @Valid MARCTransformationOptionsSettingsDTO dto){
     service.updateMARCTransformOptSet(centralServerId, dto);
+    return ResponseEntity.noContent().build();
+  }
+
+  @Override
+  @DeleteMapping("/{centralServerId}/marc-transformation-options")
+  public ResponseEntity<Void> deleteMARCTransformationOptionsSettings (@PathVariable UUID centralServerId) {
+    service.deleteMARCTransformOptSet(centralServerId);
     return ResponseEntity.noContent().build();
   }
 }

--- a/src/main/java/org/folio/innreach/domain/entity/MARCTransformationOptionsSettings.java
+++ b/src/main/java/org/folio/innreach/domain/entity/MARCTransformationOptionsSettings.java
@@ -54,4 +54,18 @@ public class MARCTransformationOptionsSettings extends Auditable<String> {
   @Column(name = "marc_field")
   @Fetch(value = org.hibernate.annotations.FetchMode.SUBSELECT)
   private List<String> excludedMARCFields = new ArrayList<>();
+
+  public void removeModifiedFieldForContributedRecords(FieldConfiguration fieldConfiguration) {
+    if (fieldConfiguration != null) {
+      fieldConfiguration.setMARCTransformationOptionsSettings(null);
+    }
+    this.modifiedFieldsForContributedRecords.remove(fieldConfiguration);
+  }
+
+  public void addModifiedFieldForContributedRecords(FieldConfiguration fieldConfiguration) {
+    if (fieldConfiguration != null) {
+      fieldConfiguration.setMARCTransformationOptionsSettings(this);
+    }
+    this.modifiedFieldsForContributedRecords.add(fieldConfiguration);
+  }
 }

--- a/src/main/java/org/folio/innreach/domain/entity/MARCTransformationOptionsSettings.java
+++ b/src/main/java/org/folio/innreach/domain/entity/MARCTransformationOptionsSettings.java
@@ -1,9 +1,13 @@
 package org.folio.innreach.domain.entity;
 
+import static org.folio.innreach.domain.entity.MARCTransformationOptionsSettings.FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY;
+import static org.folio.innreach.domain.entity.MARCTransformationOptionsSettings.FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY_NAME;
+
 import lombok.Getter;
 import lombok.Setter;
 import org.folio.innreach.domain.entity.base.Auditable;
 import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.QueryHints;
 
 import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
@@ -15,8 +19,10 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.QueryHint;
 import javax.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +32,16 @@ import java.util.UUID;
 @Getter
 @Setter
 @Table(name = "marc_transformation_options_settings")
+@NamedQuery(
+  name = FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY_NAME,
+  query = FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY,
+  hints = @QueryHint(name = QueryHints.PASS_DISTINCT_THROUGH, value = "false")
+)
 public class MARCTransformationOptionsSettings extends Auditable<String> {
+  public static final String FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY_NAME = "MARCTransformationOptionsSettings.fetchOne";
+  public static final String FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY =
+    "SELECT DISTINCT m FROM MARCTransformationOptionsSettings AS m where m.centralServer.id = :id";
+
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
   private UUID id;

--- a/src/main/java/org/folio/innreach/domain/service/MARCTransformationOptionsSettingsService.java
+++ b/src/main/java/org/folio/innreach/domain/service/MARCTransformationOptionsSettingsService.java
@@ -1,6 +1,7 @@
 package org.folio.innreach.domain.service;
 
 import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsListDTO;
 
 import java.util.UUID;
 
@@ -10,4 +11,8 @@ public interface MARCTransformationOptionsSettingsService {
   MARCTransformationOptionsSettingsDTO createMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
 
   MARCTransformationOptionsSettingsDTO updateMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+
+  void deleteMARCTransformOptSet(UUID centralServerId);
+
+  MARCTransformationOptionsSettingsListDTO getAllMARCTransformOptSet(int offset, int limit);
 }

--- a/src/main/java/org/folio/innreach/domain/service/MARCTransformationOptionsSettingsService.java
+++ b/src/main/java/org/folio/innreach/domain/service/MARCTransformationOptionsSettingsService.java
@@ -6,13 +6,13 @@ import org.folio.innreach.dto.MARCTransformationOptionsSettingsListDTO;
 import java.util.UUID;
 
 public interface MARCTransformationOptionsSettingsService {
-  MARCTransformationOptionsSettingsDTO getMARCTransformOptSet(UUID centralServerId);
+  MARCTransformationOptionsSettingsDTO get(UUID centralServerId);
 
-  MARCTransformationOptionsSettingsDTO createMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+  MARCTransformationOptionsSettingsDTO create(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
 
-  MARCTransformationOptionsSettingsDTO updateMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+  MARCTransformationOptionsSettingsDTO update(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
 
-  void deleteMARCTransformOptSet(UUID centralServerId);
+  void delete(UUID centralServerId);
 
-  MARCTransformationOptionsSettingsListDTO getAllMARCTransformOptSet(int offset, int limit);
+  MARCTransformationOptionsSettingsListDTO getAll(int offset, int limit);
 }

--- a/src/main/java/org/folio/innreach/domain/service/MARCTransformationOptionsSettingsService.java
+++ b/src/main/java/org/folio/innreach/domain/service/MARCTransformationOptionsSettingsService.java
@@ -1,0 +1,13 @@
+package org.folio.innreach.domain.service;
+
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+
+import java.util.UUID;
+
+public interface MARCTransformationOptionsSettingsService {
+  MARCTransformationOptionsSettingsDTO getMARCTransformOptSet(UUID centralServerId);
+
+  MARCTransformationOptionsSettingsDTO createMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+
+  MARCTransformationOptionsSettingsDTO updateMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
@@ -5,15 +5,20 @@ import org.folio.innreach.domain.entity.FieldConfiguration;
 import org.folio.innreach.domain.entity.MARCTransformationOptionsSettings;
 import org.folio.innreach.domain.exception.EntityNotFoundException;
 import org.folio.innreach.domain.service.MARCTransformationOptionsSettingsService;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsListDTO;
 import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
 import org.folio.innreach.mapper.MARCTransformationOptionsSettingsMapper;
 import org.folio.innreach.repository.MARCTransformationOptionsSettingsRepository;
 import org.springframework.data.domain.Example;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityExistsException;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import static org.folio.innreach.domain.service.impl.ServiceUtils.centralServerRef;
 
@@ -55,6 +60,31 @@ public class MARCTransformationOptionsSettingsServiceImpl implements MARCTransfo
     repository.save(marcTransformOptSet);
 
     return mapper.toMARCTransformationOptSetDto(marcTransformOptSet);
+  }
+
+  @Override
+  @Transactional
+  public void deleteMARCTransformOptSet(UUID centralServerId) {
+    var marcTransformOptSet = findMARCTransformOptSet(centralServerId);
+    repository.delete(marcTransformOptSet);
+  }
+
+  @Override
+  public MARCTransformationOptionsSettingsListDTO getAll(int offset, int limit) {
+    var marcTransformOptSetList = collectMARCTransformOptSet(offset, limit);
+
+    var marcTransformOptSetListDTO = new MARCTransformationOptionsSettingsListDTO();
+    marcTransformOptSetListDTO.setMaRCTransformOptSetList(marcTransformOptSetList);
+    marcTransformOptSetListDTO.setTotalRecords(marcTransformOptSetList.size());
+
+    return marcTransformOptSetListDTO;
+  }
+
+  private List<MARCTransformationOptionsSettingsDTO> collectMARCTransformOptSet(Integer offset, Integer limit){
+    return repository.findAll(PageRequest.of(offset, limit))
+      .stream()
+      .map(mapper::toMARCTransformationOptSetDto)
+      .collect(Collectors.toList());
   }
 
   private void updateMARCTransformOptSet(MARCTransformationOptionsSettings marcTransformOptSet, MARCTransformationOptionsSettings updated) {

--- a/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
@@ -1,0 +1,100 @@
+package org.folio.innreach.domain.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.innreach.domain.entity.FieldConfiguration;
+import org.folio.innreach.domain.entity.MARCTransformationOptionsSettings;
+import org.folio.innreach.domain.exception.EntityNotFoundException;
+import org.folio.innreach.domain.service.MARCTransformationOptionsSettingsService;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.folio.innreach.mapper.MARCTransformationOptionsSettingsMapper;
+import org.folio.innreach.repository.MARCTransformationOptionsSettingsRepository;
+import org.springframework.data.domain.Example;
+import org.springframework.stereotype.Service;
+
+import javax.persistence.EntityExistsException;
+import java.util.ArrayList;
+import java.util.UUID;
+
+import static org.folio.innreach.domain.service.impl.ServiceUtils.centralServerRef;
+
+@RequiredArgsConstructor
+@Service
+public class MARCTransformationOptionsSettingsServiceImpl implements MARCTransformationOptionsSettingsService {
+
+  private final MARCTransformationOptionsSettingsRepository repository;
+  private final MARCTransformationOptionsSettingsMapper mapper;
+
+  private static final String TEXT_MARC_TRANSFORM_OPT_SET_WITH_ID = "MARC Transformation Options Settings with id: ";
+
+  @Override
+  public MARCTransformationOptionsSettingsDTO getMARCTransformOptSet(UUID centralServerId) {
+    var marcTransformOptSet = findMARCTransformOptSet(centralServerId);
+    return mapper.toMARCTransformationOptSetDto(marcTransformOptSet);
+  }
+
+  @Override
+  public MARCTransformationOptionsSettingsDTO createMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
+    repository.findById(centralServerId).ifPresent(marcTransformOptSet -> {
+      throw new EntityExistsException(TEXT_MARC_TRANSFORM_OPT_SET_WITH_ID
+        + marcTransformOptSet.getCentralServer().getId() + " already exists.");
+    });
+    var marcTransformOptSet = mapper.toMARCTransformationOptSet(marcTransformOptSetDTO);
+    marcTransformOptSet.getModifiedFieldsForContributedRecords().forEach(modifiedField -> modifiedField.setMARCTransformationOptionsSettings(marcTransformOptSet));
+    marcTransformOptSet.setCentralServer(centralServerRef(centralServerId));
+    var createdMARCTransformOptSet = repository.save(marcTransformOptSet);
+    return mapper.toMARCTransformationOptSetDto(createdMARCTransformOptSet);
+  }
+
+  @Override
+  public MARCTransformationOptionsSettingsDTO updateMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
+    var marcTransformOptSet = findMARCTransformOptSet(centralServerId);
+    var updated = mapper.toMARCTransformationOptSet(marcTransformOptSetDTO);
+    updateMARCTransformOptSet(marcTransformOptSet, updated);
+    updateModifiedFields(marcTransformOptSet, updated);
+
+    repository.save(marcTransformOptSet);
+
+    return mapper.toMARCTransformationOptSetDto(marcTransformOptSet);
+  }
+
+  private void updateMARCTransformOptSet(MARCTransformationOptionsSettings marcTransformOptSet, MARCTransformationOptionsSettings updated) {
+    marcTransformOptSet.setExcludedMARCFields(updated.getExcludedMARCFields());
+    marcTransformOptSet.setConfigIsActive(updated.getConfigIsActive());
+  }
+
+  private void updateModifiedFields(MARCTransformationOptionsSettings marcTransformOptSet, MARCTransformationOptionsSettings updated) {
+    var currentModifiedFields = new ArrayList<>(marcTransformOptSet.getModifiedFieldsForContributedRecords());
+    var updatedModifiedFields = updated.getModifiedFieldsForContributedRecords();
+
+    // 1. Remove the existing database records that are no longer found in the incoming collection.
+    var modifiedFieldsToDelete = new ArrayList<>(currentModifiedFields);
+    modifiedFieldsToDelete.removeAll(updatedModifiedFields);
+    modifiedFieldsToDelete.forEach(marcTransformOptSet::removeModifiedFieldForContributedRecords);
+
+    // 2. Add the records found in the incoming collection, which cannot be found in the current database snapshot.
+    var newModifiedFields = new ArrayList<>(updatedModifiedFields);
+    newModifiedFields.removeAll(currentModifiedFields);
+    newModifiedFields.forEach(marcTransformOptSet::addModifiedFieldForContributedRecords);
+
+    // 3. Update the existing database records which can be found in the incoming collection.
+    updatedModifiedFields.removeAll(newModifiedFields);
+    for (FieldConfiguration updatedFieldConfiguration : updatedModifiedFields) {
+      updatedFieldConfiguration.setMARCTransformationOptionsSettings(marcTransformOptSet);
+      marcTransformOptSet.getModifiedFieldsForContributedRecords()
+        .set(marcTransformOptSet.getModifiedFieldsForContributedRecords().indexOf(updatedFieldConfiguration), updatedFieldConfiguration);
+    }
+  }
+
+  private MARCTransformationOptionsSettings findMARCTransformOptSet(UUID centralServerId) {
+    return repository.findOne(exampleWithServerId(centralServerId))
+      .orElseThrow(() -> new EntityNotFoundException("MARC Transformation Options Settings not found: " +
+        "centralServerId = " + centralServerId));
+  }
+
+  private static Example<MARCTransformationOptionsSettings> exampleWithServerId(UUID centralServerId) {
+    var toFind = new MARCTransformationOptionsSettings();
+    toFind.setCentralServer(centralServerRef(centralServerId));
+
+    return Example.of(toFind);
+  }
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
@@ -42,7 +42,7 @@ public class MARCTransformationOptionsSettingsServiceImpl implements MARCTransfo
   public MARCTransformationOptionsSettingsDTO create(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
     repository.findOneByCentralServerId(centralServerId).ifPresent(m -> {
       throw new EntityExistsException("MARC Transformation Options Settings for centralServerId = " + centralServerId
-        + "already exist.");
+        + "already exists.");
     });
 
     var marcTransformOptSet = mapper.toEntity(marcTransformOptSetDTO);

--- a/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImpl.java
@@ -9,13 +9,12 @@ import org.folio.innreach.dto.MARCTransformationOptionsSettingsListDTO;
 import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
 import org.folio.innreach.mapper.MARCTransformationOptionsSettingsMapper;
 import org.folio.innreach.repository.MARCTransformationOptionsSettingsRepository;
-import org.springframework.data.domain.Example;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityExistsException;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -29,43 +28,49 @@ public class MARCTransformationOptionsSettingsServiceImpl implements MARCTransfo
   private final MARCTransformationOptionsSettingsRepository repository;
   private final MARCTransformationOptionsSettingsMapper mapper;
 
-  private static final String TEXT_MARC_TRANSFORM_OPT_SET_WITH_ID = "MARC Transformation Options Settings with id: ";
+  private static final String TEXT_MARC_TRANSFORM_OPT_SET_NOT_FOUND = "MARC Transformation Options Settings not found: centralServerId =";
+  private static final Comparator<FieldConfiguration> comparator = Comparator.comparing(FieldConfiguration::getResourceIdentifierTypeId);
 
   @Override
-  public MARCTransformationOptionsSettingsDTO getMARCTransformOptSet(UUID centralServerId) {
-    var marcTransformOptSet = findMARCTransformOptSet(centralServerId);
-    return mapper.toMARCTransformationOptSetDto(marcTransformOptSet);
+  public MARCTransformationOptionsSettingsDTO get(UUID centralServerId) {
+    var marcTransformOptSet = repository.findOneByCentralServerId(centralServerId);
+    return marcTransformOptSet.map(mapper::toDto).orElseThrow(()
+      -> new EntityNotFoundException(TEXT_MARC_TRANSFORM_OPT_SET_NOT_FOUND + centralServerId));
   }
 
   @Override
-  public MARCTransformationOptionsSettingsDTO createMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
-    repository.findById(centralServerId).ifPresent(marcTransformOptSet -> {
-      throw new EntityExistsException(TEXT_MARC_TRANSFORM_OPT_SET_WITH_ID
-        + marcTransformOptSet.getCentralServer().getId() + " already exists.");
+  public MARCTransformationOptionsSettingsDTO create(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
+    repository.findOneByCentralServerId(centralServerId).ifPresent(m -> {
+      throw new EntityExistsException("MARC Transformation Options Settings for centralServerId = " + centralServerId
+        + "already exist.");
     });
-    var marcTransformOptSet = mapper.toMARCTransformationOptSet(marcTransformOptSetDTO);
+
+    var marcTransformOptSet = mapper.toEntity(marcTransformOptSetDTO);
     marcTransformOptSet.getModifiedFieldsForContributedRecords().forEach(modifiedField -> modifiedField.setMARCTransformationOptionsSettings(marcTransformOptSet));
     marcTransformOptSet.setCentralServer(centralServerRef(centralServerId));
     var createdMARCTransformOptSet = repository.save(marcTransformOptSet);
-    return mapper.toMARCTransformationOptSetDto(createdMARCTransformOptSet);
+    return mapper.toDto(createdMARCTransformOptSet);
   }
 
   @Override
-  public MARCTransformationOptionsSettingsDTO updateMARCTransformOptSet(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
-    var marcTransformOptSet = findMARCTransformOptSet(centralServerId);
-    var updated = mapper.toMARCTransformationOptSet(marcTransformOptSetDTO);
+  public MARCTransformationOptionsSettingsDTO update(UUID centralServerId, MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO) {
+    var marcTransformOptSet = repository.findOneByCentralServerId(centralServerId).orElseThrow(
+      () -> new EntityNotFoundException(TEXT_MARC_TRANSFORM_OPT_SET_NOT_FOUND + centralServerId));
+
+    var updated = mapper.toEntity(marcTransformOptSetDTO);
     updateMARCTransformOptSet(marcTransformOptSet, updated);
     updateModifiedFields(marcTransformOptSet, updated);
 
     repository.save(marcTransformOptSet);
 
-    return mapper.toMARCTransformationOptSetDto(marcTransformOptSet);
+    return mapper.toDto(marcTransformOptSet);
   }
 
   @Override
   @Transactional
-  public void deleteMARCTransformOptSet(UUID centralServerId) {
-    var marcTransformOptSet = findMARCTransformOptSet(centralServerId);
+  public void delete(UUID centralServerId) {
+    var marcTransformOptSet = repository.findOneByCentralServerId(centralServerId).orElseThrow(
+      () -> new EntityNotFoundException(TEXT_MARC_TRANSFORM_OPT_SET_NOT_FOUND + centralServerId));
     repository.delete(marcTransformOptSet);
   }
 
@@ -80,10 +85,10 @@ public class MARCTransformationOptionsSettingsServiceImpl implements MARCTransfo
     return marcTransformOptSetListDTO;
   }
 
-  private List<MARCTransformationOptionsSettingsDTO> collectMARCTransformOptSet(Integer offset, Integer limit){
+  private List<MARCTransformationOptionsSettingsDTO> collectMARCTransformOptSet(Integer offset, Integer limit) {
     return repository.findAll(PageRequest.of(offset, limit))
       .stream()
-      .map(mapper::toMARCTransformationOptSetDto)
+      .map(mapper::toDto)
       .collect(Collectors.toList());
   }
 
@@ -93,38 +98,13 @@ public class MARCTransformationOptionsSettingsServiceImpl implements MARCTransfo
   }
 
   private void updateModifiedFields(MARCTransformationOptionsSettings marcTransformOptSet, MARCTransformationOptionsSettings updated) {
-    var currentModifiedFields = new ArrayList<>(marcTransformOptSet.getModifiedFieldsForContributedRecords());
-    var updatedModifiedFields = updated.getModifiedFieldsForContributedRecords();
-
-    // 1. Remove the existing database records that are no longer found in the incoming collection.
-    var modifiedFieldsToDelete = new ArrayList<>(currentModifiedFields);
-    modifiedFieldsToDelete.removeAll(updatedModifiedFields);
-    modifiedFieldsToDelete.forEach(marcTransformOptSet::removeModifiedFieldForContributedRecords);
-
-    // 2. Add the records found in the incoming collection, which cannot be found in the current database snapshot.
-    var newModifiedFields = new ArrayList<>(updatedModifiedFields);
-    newModifiedFields.removeAll(currentModifiedFields);
-    newModifiedFields.forEach(marcTransformOptSet::addModifiedFieldForContributedRecords);
-
-    // 3. Update the existing database records which can be found in the incoming collection.
-    updatedModifiedFields.removeAll(newModifiedFields);
-    for (FieldConfiguration updatedFieldConfiguration : updatedModifiedFields) {
-      updatedFieldConfiguration.setMARCTransformationOptionsSettings(marcTransformOptSet);
-      marcTransformOptSet.getModifiedFieldsForContributedRecords()
-        .set(marcTransformOptSet.getModifiedFieldsForContributedRecords().indexOf(updatedFieldConfiguration), updatedFieldConfiguration);
-    }
+    ServiceUtils.merge(updated.getModifiedFieldsForContributedRecords(), marcTransformOptSet.getModifiedFieldsForContributedRecords(), comparator, marcTransformOptSet::addModifiedFieldForContributedRecords,
+      this::updateModifiedFieldData, marcTransformOptSet::removeModifiedFieldForContributedRecords);
   }
 
-  private MARCTransformationOptionsSettings findMARCTransformOptSet(UUID centralServerId) {
-    return repository.findOne(exampleWithServerId(centralServerId))
-      .orElseThrow(() -> new EntityNotFoundException("MARC Transformation Options Settings not found: " +
-        "centralServerId = " + centralServerId));
+  private void updateModifiedFieldData(FieldConfiguration incoming, FieldConfiguration existing) {
+    existing.setStripPrefix(incoming.getStripPrefix());
+    existing.setIgnorePrefixes(incoming.getIgnorePrefixes());
   }
 
-  private static Example<MARCTransformationOptionsSettings> exampleWithServerId(UUID centralServerId) {
-    var toFind = new MARCTransformationOptionsSettings();
-    toFind.setCentralServer(centralServerRef(centralServerId));
-
-    return Example.of(toFind);
-  }
 }

--- a/src/main/java/org/folio/innreach/mapper/MARCTransformationOptionsSettingsMapper.java
+++ b/src/main/java/org/folio/innreach/mapper/MARCTransformationOptionsSettingsMapper.java
@@ -13,7 +13,7 @@ public interface MARCTransformationOptionsSettingsMapper {
   @Mapping(target = "metadata.createdByUsername", source = "marcTransformOptSet.createdBy")
   @Mapping(target = "metadata.updatedDate", source = "marcTransformOptSet.lastModifiedDate")
   @Mapping(target = "metadata.updatedByUsername", source = "marcTransformOptSet.lastModifiedBy")
-  MARCTransformationOptionsSettingsDTO toMARCTransformationOptSetDto(MARCTransformationOptionsSettings marcTransformOptSet);
+  MARCTransformationOptionsSettingsDTO toDto(MARCTransformationOptionsSettings marcTransformOptSet);
 
-  MARCTransformationOptionsSettings toMARCTransformationOptSet(MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+  MARCTransformationOptionsSettings toEntity(MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
 }

--- a/src/main/java/org/folio/innreach/mapper/MARCTransformationOptionsSettingsMapper.java
+++ b/src/main/java/org/folio/innreach/mapper/MARCTransformationOptionsSettingsMapper.java
@@ -1,0 +1,19 @@
+package org.folio.innreach.mapper;
+
+import org.folio.innreach.domain.entity.MARCTransformationOptionsSettings;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, uses = DateMapper.class)
+public interface MARCTransformationOptionsSettingsMapper {
+
+  @Mapping(target = "metadata.createdDate", source = "marcTransformOptSet.createdDate")
+  @Mapping(target = "metadata.createdByUsername", source = "marcTransformOptSet.createdBy")
+  @Mapping(target = "metadata.updatedDate", source = "marcTransformOptSet.lastModifiedDate")
+  @Mapping(target = "metadata.updatedByUsername", source = "marcTransformOptSet.lastModifiedBy")
+  MARCTransformationOptionsSettingsDTO toMARCTransformationOptSetDto(MARCTransformationOptionsSettings marcTransformOptSet);
+
+  MARCTransformationOptionsSettings toMARCTransformationOptSet(MARCTransformationOptionsSettingsDTO marcTransformOptSetDTO);
+}

--- a/src/main/java/org/folio/innreach/repository/MARCTransformationOptionsSettingsRepository.java
+++ b/src/main/java/org/folio/innreach/repository/MARCTransformationOptionsSettingsRepository.java
@@ -2,10 +2,14 @@ package org.folio.innreach.repository;
 
 import org.folio.innreach.domain.entity.MARCTransformationOptionsSettings;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
 public interface MARCTransformationOptionsSettingsRepository extends JpaRepository<MARCTransformationOptionsSettings, UUID> {
+  @Query(name = MARCTransformationOptionsSettings.FETCH_ONE_BY_CENTRAL_SERVER_ID_QUERY_NAME)
+  Optional<MARCTransformationOptionsSettings> findOneByCentralServerId(UUID id);
 }

--- a/src/main/resources/swagger.api/inn-reach.yaml
+++ b/src/main/resources/swagger.api/inn-reach.yaml
@@ -723,7 +723,7 @@ paths:
                 $ref: "#/components/schemas/MARCTransformationOptionsSettingsListDTO"
         '500':
           $ref: "#/components/responses/trait_response_500"
-      description: Get a Marc Transformation Options Settings
+      description: Get a list of Marc Transformation Options Settings
       operationId: getAllMARCTransformationOptionsSettings
       parameters:
         - $ref: "#/components/parameters/trait_pageable_offset"

--- a/src/main/resources/swagger.api/inn-reach.yaml
+++ b/src/main/resources/swagger.api/inn-reach.yaml
@@ -696,6 +696,38 @@ paths:
         required: true
       parameters:
         - $ref: '#/components/parameters/centralServerId'
+    delete:
+      tags:
+        - M-A-R-C-transformation-options-settings
+      responses:
+        '204':
+          description: No content
+        '404':
+          $ref: "#/components/responses/trait_response_404"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      description: Delete Marc Transformation Options Settings
+      operationId: deleteMARCTransformationOptionsSettings
+      parameters:
+        - $ref: '#/components/parameters/centralServerId'
+  /central-servers/marc-transformation-options:
+    get:
+      tags:
+        - M-A-R-C-transformation-options-settings
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MARCTransformationOptionsSettingsListDTO"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      description: Get a Marc Transformation Options Settings
+      operationId: getAllMARCTransformationOptionsSettings
+      parameters:
+        - $ref: "#/components/parameters/trait_pageable_offset"
+        - $ref: "#/components/parameters/trait_pageable_limit"
 components:
   schemas:
     UUID:
@@ -740,6 +772,8 @@ components:
       $ref: schemas/agencyLocationMappingDTO.json
     MARCTransformationOptionsSettingsDTO:
       $ref: schemas/MARCTransformationOptionsSettingsDTO.json
+    MARCTransformationOptionsSettingsListDTO:
+      $ref: schemas/MARCTransformationOptionsSettingsListDTO.json
   parameters:
     id:
       name: id

--- a/src/main/resources/swagger.api/inn-reach.yaml
+++ b/src/main/resources/swagger.api/inn-reach.yaml
@@ -632,6 +632,70 @@ paths:
         required: true
       parameters:
         - $ref: "#/components/parameters/centralServerId"
+  /central-servers/{centralServerId}/marc-transformation-options:
+    get:
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MARCTransformationOptionsSettingsDTO"
+        '404':
+          $ref: "#/components/responses/trait_response_404"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      description: Get MARC Transformation Options Settings by id
+      operationId: getMARCTransformationOptionsSettingsById
+      tags:
+        - M-A-R-C-transformation-options-settings
+      parameters:
+        - $ref: '#/components/parameters/centralServerId'
+    put:
+      responses:
+        '204':
+          description: No content
+        '400':
+          $ref: "#/components/responses/trait_response_validation_400"
+        '404':
+          $ref: "#/components/responses/trait_response_404"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      description: Update MARC Transformation Options Settings
+      operationId: updateMARCTransformationOptionsSettings
+      tags:
+        - M-A-R-C-transformation-options-settings
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MARCTransformationOptionsSettingsDTO"
+      parameters:
+        - $ref: '#/components/parameters/centralServerId'
+    post:
+      description: Add new MARC Transformation Options Settings associated with the central server
+      operationId: createMARCTransformationOptionsSettings
+      tags:
+        - M-A-R-C-transformation-options-settings
+      responses:
+        '201':
+          description: MARC Transformation Options Settings created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MARCTransformationOptionsSettingsDTO"
+        '400':
+          $ref: "#/components/responses/trait_response_validation_400"
+        '500':
+          $ref: "#/components/responses/trait_response_500"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MARCTransformationOptionsSettingsDTO"
+        required: true
+      parameters:
+        - $ref: '#/components/parameters/centralServerId'
 components:
   schemas:
     UUID:
@@ -674,6 +738,8 @@ components:
       $ref: schemas/itemContributionOptionsConfigurationDTO.json
     agencyLocationMappingDTO:
       $ref: schemas/agencyLocationMappingDTO.json
+    MARCTransformationOptionsSettingsDTO:
+      $ref: schemas/MARCTransformationOptionsSettingsDTO.json
   parameters:
     id:
       name: id

--- a/src/main/resources/swagger.api/schemas/MARCTransformationOptionsSettingsDTO.json
+++ b/src/main/resources/swagger.api/schemas/MARCTransformationOptionsSettingsDTO.json
@@ -1,0 +1,35 @@
+{
+  "description": "MARC Transformation Options Settings",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "MARC Transformation Options Settings id",
+      "type": "string",
+      "format": "UUID"
+    },
+    "configIsActive": {
+      "description": "A Boolean indicating whether the configuration is active",
+      "type": "boolean"
+    },
+    "modifiedFieldsForContributedRecords": {
+      "description": "An ordered array of field configurations",
+      "type": "array",
+      "items": {
+        "$ref": "fieldConfigurationDTO.json"
+      }
+    },
+    "excludedMARCFields": {
+      "description": "An array of MARC fields/subfields to exclude from transformed MARC records",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "metadata": {
+      "description": "Entity metadata",
+      "type": "object",
+      "$ref": "metadata.json"
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/main/resources/swagger.api/schemas/MARCTransformationOptionsSettingsListDTO.json
+++ b/src/main/resources/swagger.api/schemas/MARCTransformationOptionsSettingsListDTO.json
@@ -1,0 +1,21 @@
+{
+  "description": "MARC Transformation Options Settings collection",
+  "type": "object",
+  "properties": {
+    "totalRecords": {
+      "description": "Total records",
+      "type": "integer"
+    },
+    "MARCTransformOptSetList": {
+      "description": "List of MARC Transformation Options Settings",
+      "type": "array",
+      "items": {
+        "$ref": "MARCTransformationOptionsSettingsDTO.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "MARCTransformOptSetList"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/fieldConfigurationDTO.json
+++ b/src/main/resources/swagger.api/schemas/fieldConfigurationDTO.json
@@ -22,6 +22,11 @@
       "items": {
         "type": "string"
       }
+    },
+    "metadata": {
+      "description": "Entity metadata",
+      "type": "object",
+      "$ref": "metadata.json"
     }
   },
   "additionalProperties": false

--- a/src/main/resources/swagger.api/schemas/fieldConfigurationDTO.json
+++ b/src/main/resources/swagger.api/schemas/fieldConfigurationDTO.json
@@ -1,0 +1,28 @@
+{
+  "description": "Field Configuration",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Field configuration id",
+      "type": "string",
+      "format": "UUID"
+    },
+    "resourceIdentifierTypeId": {
+      "description": "Resource identifier type id",
+      "type": "string",
+      "format": "UUID"
+    },
+    "stripPrefix": {
+      "description": "Strip prefix",
+      "type": "boolean"
+    },
+    "ignorePrefixes": {
+      "description": "Array of strings that if present as prefixes will cause the identifier to be ignored",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/test/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsControllerTest.java
@@ -2,6 +2,7 @@ package org.folio.innreach.controller;
 
 import org.folio.innreach.controller.base.BaseControllerTest;
 import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsListDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -57,6 +58,26 @@ class MARCTransformationOptionsSettingsControllerTest extends BaseControllerTest
 
   @Test
   @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/marc-transform-opt-set/pre-populate-marc-transform-opt-set.sql"
+  })
+  void return200HttpCode_and_allMARCTransformOptSetEntities_when_getForAllMARCTransformOptSet() {
+    var responseEntity = testRestTemplate.getForEntity(
+      "/inn-reach/central-servers/marc-transformation-options", MARCTransformationOptionsSettingsListDTO.class);
+
+    assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
+    assertTrue(responseEntity.hasBody());
+
+    var marcTransformOptSetList = responseEntity.getBody();
+
+    assertNotNull(marcTransformOptSetList);
+    assertNotNull(marcTransformOptSetList.getMaRCTransformOptSetList());
+    assertEquals(1, marcTransformOptSetList.getMaRCTransformOptSetList().size());
+    assertEquals(1, marcTransformOptSetList.getTotalRecords());
+  }
+
+  @Test
+  @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql"
   })
   void return200HttpCode_and_createdMARCTransformOptSetEntity_when_createMARCTransformOptSet() {
@@ -104,5 +125,18 @@ class MARCTransformationOptionsSettingsControllerTest extends BaseControllerTest
       PRE_POPULATED_CENTRAL_SERVER_ID);
 
     assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/marc-transform-opt-set/pre-populate-marc-transform-opt-set.sql"
+  })
+  void return204HttpCode_when_deleteMARCTransformOptSet() {
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/central-servers/{centralServerId}/marc-transformation-options", HttpMethod.DELETE, HttpEntity.EMPTY,
+      MARCTransformationOptionsSettingsDTO.class, PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
   }
 }

--- a/src/test/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/MARCTransformationOptionsSettingsControllerTest.java
@@ -1,0 +1,108 @@
+package org.folio.innreach.controller;
+
+import org.folio.innreach.controller.base.BaseControllerTest;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+import java.util.UUID;
+
+import static org.folio.innreach.fixture.TestUtil.deserializeFromJsonFile;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+
+@Sql(
+  scripts = {
+    "classpath:db/marc-transform-opt-set/clear-marc-transform-opt-set-tables.sql",
+    "classpath:db/central-server/clear-central-server-tables.sql"
+  },
+  executionPhase = AFTER_TEST_METHOD
+)
+@SqlMergeMode(MERGE)
+class MARCTransformationOptionsSettingsControllerTest extends BaseControllerTest {
+  private static final String PRE_POPULATED_MARC_TRANSFORM_OPT_SET_ID = "51768f15-41e8-494d-bc4d-a308568e7052";
+  private static final String PRE_POPULATED_CENTRAL_SERVER_ID = "edab6baf-c696-42b1-89bb-1bbb8759b0d2";
+
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+
+  @Test
+  @Sql(scripts = {"classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/marc-transform-opt-set/pre-populate-marc-transform-opt-set.sql"
+  })
+  void return200HttpCode_and_marcTransformOptSet_when_getForOneMARCTransformOptSet() {
+    var responseEntity = testRestTemplate.getForEntity(
+      "/inn-reach/central-servers/{centralServerId}/marc-transformation-options", MARCTransformationOptionsSettingsDTO.class,
+      PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertTrue(responseEntity.hasBody());
+
+    var marcTransformOptSetDTO = responseEntity.getBody();
+
+    assertEquals(UUID.fromString(PRE_POPULATED_MARC_TRANSFORM_OPT_SET_ID), marcTransformOptSetDTO.getId());
+    assertNotNull(marcTransformOptSetDTO.getExcludedMARCFields());
+    assertNotNull(marcTransformOptSetDTO.getConfigIsActive());
+    assertNotNull(marcTransformOptSetDTO.getModifiedFieldsForContributedRecords());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql"
+  })
+  void return200HttpCode_and_createdMARCTransformOptSetEntity_when_createMARCTransformOptSet() {
+    var marcTransformOptSetDTO = deserializeFromJsonFile(
+      "/marc-transform-opt-set/create-marc-transform-opt-set-request.json", MARCTransformationOptionsSettingsDTO.class);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/central-servers/{centralServerId}/marc-transformation-options", marcTransformOptSetDTO, MARCTransformationOptionsSettingsDTO.class,
+      PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertEquals(HttpStatus.CREATED, responseEntity.getStatusCode());
+    assertTrue(responseEntity.hasBody());
+
+    var created = responseEntity.getBody();
+
+    assertNotNull(created);
+    assertNotNull(created.getId());
+    assertEquals(marcTransformOptSetDTO.getConfigIsActive(), created.getConfigIsActive());
+    assertEquals(marcTransformOptSetDTO.getExcludedMARCFields(), created.getExcludedMARCFields());
+    assertEquals(marcTransformOptSetDTO.getModifiedFieldsForContributedRecords().size(), created.getModifiedFieldsForContributedRecords().size());
+  }
+
+  @Test
+  @Sql(scripts = {"classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/marc-transform-opt-set/pre-populate-marc-transform-opt-set.sql"
+  })
+  void return204HttpCode_when_updateMARCTransformOptSet() {
+    var marcTransformOptSetDTO = deserializeFromJsonFile(
+      "/marc-transform-opt-set/update-marc-transform-opt-set-request.json", MARCTransformationOptionsSettingsDTO.class);
+
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/central-servers/{centralServerId}/marc-transformation-options", HttpMethod.PUT, new HttpEntity<>(marcTransformOptSetDTO),
+      MARCTransformationOptionsSettingsDTO.class, PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql"
+  })
+  void return404HttpCode_when_marcTransformOptSetByIdNotFound() {
+    var responseEntity = testRestTemplate.getForEntity(
+      "/inn-reach/central-servers/{centralServerId}/marc-transformation-options", MARCTransformationOptionsSettingsDTO.class,
+      PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+  }
+}

--- a/src/test/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImplTest.java
@@ -43,11 +43,11 @@ class MARCTransformationOptionsSettingsServiceImplTest {
 
   @Test
   void getMARCTransformOptSet_when_marcTransformOptSetExists() {
-    when(repository.findOne(any())).thenReturn(Optional.of(createMARCTransformOptSet()));
+    when(repository.findOneByCentralServerId(any())).thenReturn(Optional.of(createMARCTransformOptSet()));
 
-    var marcTransformOptSet = service.getMARCTransformOptSet(UUID.randomUUID());
+    var marcTransformOptSet = service.get(UUID.randomUUID());
 
-    verify(repository).findOne(any());
+    verify(repository).findOneByCentralServerId(any());
 
     assertNotNull(marcTransformOptSet);
   }
@@ -58,9 +58,9 @@ class MARCTransformationOptionsSettingsServiceImplTest {
 
     when(repository.save(any(MARCTransformationOptionsSettings.class))).thenReturn(new MARCTransformationOptionsSettings());
 
-    var created = service.createMARCTransformOptSet(UUID.randomUUID(), marcTransformOptSetDTO);
+    var created = service.create(UUID.randomUUID(), marcTransformOptSetDTO);
 
-    verify(mapper).toMARCTransformationOptSet(any(MARCTransformationOptionsSettingsDTO.class));
+    verify(mapper).toEntity(any(MARCTransformationOptionsSettingsDTO.class));
     verify(repository).save(any(MARCTransformationOptionsSettings.class));
 
     assertNotNull(created);
@@ -68,13 +68,13 @@ class MARCTransformationOptionsSettingsServiceImplTest {
 
   @Test
   void updateMARCTransformOptSet_when_marcTransformOptSetExists() {
-    when(repository.findOne(any())).thenReturn(Optional.of(createMARCTransformOptSet()));
+    when(repository.findOneByCentralServerId(any())).thenReturn(Optional.of(createMARCTransformOptSet()));
 
     var updated = createMARCTransformOptSetDTO();
 
-    var updatedDTO = service.updateMARCTransformOptSet(UUID.randomUUID(), updated);
+    var updatedDTO = service.update(UUID.randomUUID(), updated);
 
-    verify(repository).findOne(any());
+    verify(repository).findOneByCentralServerId(any());
 
     assertNotNull(updatedDTO);
     assertEquals(updated.getModifiedFieldsForContributedRecords().size(), updatedDTO.getModifiedFieldsForContributedRecords().size());
@@ -84,12 +84,12 @@ class MARCTransformationOptionsSettingsServiceImplTest {
 
   @Test
   void throwException_when_marcTransformOptSetDoesNotExist() {
-    when(repository.findOne(any())).thenReturn(Optional.empty());
+    when(repository.findOneByCentralServerId(any())).thenReturn(Optional.empty());
 
     UUID id = UUID.randomUUID();
 
-    assertThrows(EntityNotFoundException.class, () -> service.getMARCTransformOptSet(id));
+    assertThrows(EntityNotFoundException.class, () -> service.get(id));
 
-    verify(repository).findOne(any());
+    verify(repository).findOneByCentralServerId(any());
   }
 }

--- a/src/test/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/MARCTransformationOptionsSettingsServiceImplTest.java
@@ -1,0 +1,95 @@
+package org.folio.innreach.domain.service.impl;
+
+import org.folio.innreach.domain.entity.MARCTransformationOptionsSettings;
+import org.folio.innreach.domain.exception.EntityNotFoundException;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
+import org.folio.innreach.mapper.DateMapper;
+import org.folio.innreach.mapper.MARCTransformationOptionsSettingsMapper;
+import org.folio.innreach.mapper.MARCTransformationOptionsSettingsMapperImpl;
+import org.folio.innreach.repository.MARCTransformationOptionsSettingsRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.folio.innreach.fixture.MARCTransformationOptionsSettingsFixture.createMARCTransformOptSet;
+import static org.folio.innreach.fixture.MARCTransformationOptionsSettingsFixture.createMARCTransformOptSetDTO;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class MARCTransformationOptionsSettingsServiceImplTest {
+  @Mock
+  private MARCTransformationOptionsSettingsRepository repository;
+
+  @Spy
+  private final MARCTransformationOptionsSettingsMapper mapper = new MARCTransformationOptionsSettingsMapperImpl(new DateMapper());
+
+  @InjectMocks
+  private MARCTransformationOptionsSettingsServiceImpl service;
+
+  @BeforeEach
+  public void beforeEachSetup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  void getMARCTransformOptSet_when_marcTransformOptSetExists() {
+    when(repository.findOne(any())).thenReturn(Optional.of(createMARCTransformOptSet()));
+
+    var marcTransformOptSet = service.getMARCTransformOptSet(UUID.randomUUID());
+
+    verify(repository).findOne(any());
+
+    assertNotNull(marcTransformOptSet);
+  }
+
+  @Test
+  void createMARCTransformOptSet_when_centralServerIsNew() {
+    var marcTransformOptSetDTO = createMARCTransformOptSetDTO();
+
+    when(repository.save(any(MARCTransformationOptionsSettings.class))).thenReturn(new MARCTransformationOptionsSettings());
+
+    var created = service.createMARCTransformOptSet(UUID.randomUUID(), marcTransformOptSetDTO);
+
+    verify(mapper).toMARCTransformationOptSet(any(MARCTransformationOptionsSettingsDTO.class));
+    verify(repository).save(any(MARCTransformationOptionsSettings.class));
+
+    assertNotNull(created);
+  }
+
+  @Test
+  void updateMARCTransformOptSet_when_marcTransformOptSetExists() {
+    when(repository.findOne(any())).thenReturn(Optional.of(createMARCTransformOptSet()));
+
+    var updated = createMARCTransformOptSetDTO();
+
+    var updatedDTO = service.updateMARCTransformOptSet(UUID.randomUUID(), updated);
+
+    verify(repository).findOne(any());
+
+    assertNotNull(updatedDTO);
+    assertEquals(updated.getModifiedFieldsForContributedRecords().size(), updatedDTO.getModifiedFieldsForContributedRecords().size());
+    assertEquals(updated.getConfigIsActive(), updatedDTO.getConfigIsActive());
+    assertEquals(updated.getExcludedMARCFields(), updatedDTO.getExcludedMARCFields());
+  }
+
+  @Test
+  void throwException_when_marcTransformOptSetDoesNotExist() {
+    when(repository.findOne(any())).thenReturn(Optional.empty());
+
+    UUID id = UUID.randomUUID();
+
+    assertThrows(EntityNotFoundException.class, () -> service.getMARCTransformOptSet(id));
+
+    verify(repository).findOne(any());
+  }
+}

--- a/src/test/java/org/folio/innreach/fixture/MARCTransformationOptionsSettingsFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/MARCTransformationOptionsSettingsFixture.java
@@ -2,20 +2,22 @@ package org.folio.innreach.fixture;
 
 import org.folio.innreach.domain.entity.FieldConfiguration;
 import org.folio.innreach.domain.entity.MARCTransformationOptionsSettings;
+import org.folio.innreach.dto.FieldConfigurationDTO;
+import org.folio.innreach.dto.MARCTransformationOptionsSettingsDTO;
 
 import java.util.Random;
 import java.util.UUID;
 
 public class MARCTransformationOptionsSettingsFixture {
 
-  public static MARCTransformationOptionsSettings createMARCTransformOptSet(){
+  public static MARCTransformationOptionsSettings createMARCTransformOptSet() {
     MARCTransformationOptionsSettings MARCTransformOptSet = new MARCTransformationOptionsSettings();
     MARCTransformOptSet.setConfigIsActive(new Random().nextBoolean());
     MARCTransformOptSet.getExcludedMARCFields().add("020");
     MARCTransformOptSet.getExcludedMARCFields().add("035");
 
-    int fieldConfigsSize = new Random().nextInt(10);
-    for (int i = 0; i < fieldConfigsSize; i++){
+    int fieldConfigsSize = new Random().nextInt(10) + 1;
+    for (int i = 0; i < fieldConfigsSize; i++) {
       MARCTransformOptSet.getModifiedFieldsForContributedRecords().add(createFieldConfig());
     }
 
@@ -28,6 +30,29 @@ public class MARCTransformationOptionsSettingsFixture {
     fieldConfig.setStripPrefix(new Random().nextBoolean());
     fieldConfig.getIgnorePrefixes().add("LCCN");
     fieldConfig.getIgnorePrefixes().add("lccn");
+    return fieldConfig;
+  }
+
+  public static MARCTransformationOptionsSettingsDTO createMARCTransformOptSetDTO() {
+    MARCTransformationOptionsSettingsDTO MARCTransformOptSetDTO = new MARCTransformationOptionsSettingsDTO();
+    MARCTransformOptSetDTO.setConfigIsActive(new Random().nextBoolean());
+    MARCTransformOptSetDTO.addExcludedMARCFieldsItem("020");
+    MARCTransformOptSetDTO.addExcludedMARCFieldsItem("035");
+
+    int fieldConfigsSize = new Random().nextInt(10) + 1;
+    for (int i = 0; i < fieldConfigsSize; i++) {
+      MARCTransformOptSetDTO.addModifiedFieldsForContributedRecordsItem(createFieldConfigDTO());
+    }
+
+    return MARCTransformOptSetDTO;
+  }
+
+  public static FieldConfigurationDTO createFieldConfigDTO() {
+    FieldConfigurationDTO fieldConfig = new FieldConfigurationDTO();
+    fieldConfig.setResourceIdentifierTypeId(UUID.randomUUID());
+    fieldConfig.setStripPrefix(new Random().nextBoolean());
+    fieldConfig.addIgnorePrefixesItem("LCCN");
+    fieldConfig.addIgnorePrefixesItem("lccn");
     return fieldConfig;
   }
 }

--- a/src/test/java/org/folio/innreach/repository/MARCTransformationOptionsSettingsRepositoryTest.java
+++ b/src/test/java/org/folio/innreach/repository/MARCTransformationOptionsSettingsRepositoryTest.java
@@ -77,11 +77,11 @@ class MARCTransformationOptionsSettingsRepositoryTest extends BaseRepositoryTest
   @Test
   @Sql(scripts = {"classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/marc-transform-opt-set/pre-populate-marc-transform-opt-set.sql"})
-  void deleteItmContribOptConf_when_itmContribOptConfExists() {
+  void deleteMARCTransformOptSet_when_marcTransformOptSetExists() {
     UUID id = UUID.fromString(PRE_POPULATED_MARC_TRANSFORM_OPT_SET_ID);
     repository.deleteById(id);
 
-    Optional<MARCTransformationOptionsSettings> deletedItmContribOptConf = repository.findById(id);
-    assertTrue(deletedItmContribOptConf.isEmpty());
+    Optional<MARCTransformationOptionsSettings> deleted = repository.findById(id);
+    assertTrue(deleted.isEmpty());
   }
 }

--- a/src/test/resources/json/marc-transform-opt-set/create-marc-transform-opt-set-request.json
+++ b/src/test/resources/json/marc-transform-opt-set/create-marc-transform-opt-set-request.json
@@ -1,0 +1,22 @@
+{
+  "configIsActive" : "true",
+  "modifiedFieldsForContributedRecords" : [
+    {
+      "resourceIdentifierTypeId" : "69b84781-4194-4f17-a634-3d211d59be1f",
+      "stripPrefix" : "true",
+      "ignorePrefixes" : [
+        "FOO", "fod"
+      ]
+    },
+    {
+      "resourceIdentifierTypeId" : "05ac9d6a-ab17-40cd-9247-eef98c83b922",
+      "stripPrefix" : "false",
+      "ignorePrefixes" : [
+        "LC", "lc"
+      ]
+    }
+  ],
+  "excludedMARCFields": [
+    "086"
+  ]
+}

--- a/src/test/resources/json/marc-transform-opt-set/update-marc-transform-opt-set-request.json
+++ b/src/test/resources/json/marc-transform-opt-set/update-marc-transform-opt-set-request.json
@@ -1,0 +1,20 @@
+{
+  "configIsActive" : "false",
+  "modifiedFieldsForContributedRecords" : [
+    {
+      "resourceIdentifierTypeId" : "69b84781-4194-4f17-a634-3d211d59be1f",
+      "stripPrefix" : "false",
+      "ignorePrefixes" : [
+        "FOO", "fod", "LC", "lc"
+      ]
+    },
+    {
+      "resourceIdentifierTypeId" : "37c027e9-2cc4-42f0-8b6c-975ede955c43",
+      "stripPrefix" : "true",
+      "ignorePrefixes" : [
+        "OCM"
+      ]
+    }
+  ],
+  "excludedMARCFields": []
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->
Create API to CRUD Data Model to Store Contributed MARC Transformation Options Settings for INN-Reach Central Servers.
JIRA: [MODINREACH-50](https://issues.folio.org/browse/MODINREACH-50)
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
- MARC Transformation Options Settings Service created
- MARC Transformation Options Settings Controller created
- OpenAPI configuration updated
- JSON schema forMARC Transformation Options Settings DTO added
- Tests for MARC Transformation Options Settings Service and Controller added
- JSON request files for controller tests added
- ModuleDescriptor updated
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
