### PR TITLE
MODINREACH-116 Circulation status mapping GET Error 500

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/ItemContributionOptionsConfigurationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ItemContributionOptionsConfigurationServiceImpl.java
@@ -11,7 +11,6 @@ import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.persistence.EntityExistsException;
 import java.util.UUID;
 
 import static org.folio.innreach.domain.service.impl.ServiceUtils.centralServerRef;
@@ -23,8 +22,6 @@ public class ItemContributionOptionsConfigurationServiceImpl implements ItemCont
   private final ItemContributionOptionsConfigurationRepository repository;
   private final ItemContributionOptionsConfigurationMapper mapper;
 
-  private static final String TEXT_ITM_CONTRIB_OPT_CONFIG_WITH_ID = "Item Contribution Options Configuration with id: ";
-
   @Override
   @Transactional(readOnly = true)
   public ItemContributionOptionsConfigurationDTO getItmContribOptConf(UUID centralServerId) {
@@ -34,10 +31,6 @@ public class ItemContributionOptionsConfigurationServiceImpl implements ItemCont
 
   @Override
   public ItemContributionOptionsConfigurationDTO createItmContribOptConf(UUID centralServerId, ItemContributionOptionsConfigurationDTO itmContribOptConfDTO) {
-    repository.findById(centralServerId).ifPresent(itmContribOptConf -> {
-      throw new EntityExistsException(TEXT_ITM_CONTRIB_OPT_CONFIG_WITH_ID
-        + itmContribOptConf.getCentralServer().getId() + " already exists.");
-    });
     var itmContribOptConf = mapper.toEntity(itmContribOptConfDTO);
     itmContribOptConf.setCentralServer(centralServerRef(centralServerId));
     var createdItmContribOptConf = repository.save(itmContribOptConf);

--- a/src/main/resources/db/changelog/changes/v1.0.0/2021-08-04-MODINREACH-116.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/2021-08-04-MODINREACH-116.xml
@@ -1,0 +1,11 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  <changeSet id="2021-08-04-01__alter-itm-contrib-opt-conf-table" author="maryna_steshenko">
+    <sqlFile path="sql/2021-08-04-01__alter-itm-contrib-opt-conf-table.sql" relativeToChangelogFile="true"/>
+  </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.0/changelog-v1.0.0.xml
+++ b/src/main/resources/db/changelog/changes/v1.0.0/changelog-v1.0.0.xml
@@ -20,4 +20,5 @@
     <include file="2021-07-21-MODINREACH-49.xml" relativeToChangelogFile="true"/>
     <include file="2021-07-22-MODINREACH-115.xml" relativeToChangelogFile="true"/>
     <include file="2021-07-28-MODINREACH-65.xml" relativeToChangelogFile="true"/>
+    <include file="2021-08-04-MODINREACH-116.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/changes/v1.0.0/sql/2021-08-04-01__alter-itm-contrib-opt-conf-table.sql
+++ b/src/main/resources/db/changelog/changes/v1.0.0/sql/2021-08-04-01__alter-itm-contrib-opt-conf-table.sql
@@ -1,0 +1,5 @@
+DELETE FROM item_contribution_options_configuration item1 USING item_contribution_options_configuration item2
+WHERE item1.central_server_id = item2.central_server_id AND
+GREATEST(item1.created_date, item1.last_modified_date) < GREATEST(item2.created_date, item2.last_modified_date);
+
+ALTER TABLE item_contribution_options_configuration ADD CONSTRAINT unq_central_server_id UNIQUE (central_server_id);

--- a/src/test/java/org/folio/innreach/controller/ItemContributionOptionsConfigurationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/ItemContributionOptionsConfigurationControllerTest.java
@@ -14,6 +14,8 @@ import org.springframework.test.context.jdbc.SqlMergeMode;
 import java.util.UUID;
 
 import static org.folio.innreach.fixture.TestUtil.deserializeFromJsonFile;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -121,5 +123,23 @@ class ItemContributionOptionsConfigurationControllerTest extends BaseControllerT
       PRE_POPULATED_CENTRAL_SERVER_ID);
 
     assertEquals(HttpStatus.NOT_FOUND, responseEntity.getStatusCode());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/itm-contrib-opt-conf/pre-populate-itm-contrib-opt-conf.sql"
+  })
+  void return409HttpCode_when_creatingItmContribOptConfWhenItmContribOptConfExists() {
+    var itmContribOptConfDTO = deserializeFromJsonFile(
+      "/item-contribution-options/create-itm-contrib-opt-conf-request.json", ItemContributionOptionsConfigurationDTO.class);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/central-servers/{centralServerId}/item-contribution-options", itmContribOptConfDTO, Error.class,
+      PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertEquals(HttpStatus.CONFLICT, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+    assertThat(responseEntity.getBody().getMessage(), containsString("constraint [unq_central_server_id]"));
   }
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->
Fix Circulation status mapping GET Error 500.
## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->
The cause of the bug was that there were multiple instances of ItemContributionOptionsConfiguration created for one CentralServer thus GET method couldn't get one object.
- SQL script that deletes all duplicate except for the latest entry and adds UNIQUE constraint added.
- Test for ItemContributionOptionsConfiguration controller added.
## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
