### PR TITLE
MODINNREACH-118 Add internal system user

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ curl -w '\n' -X POST -D -   \
     http://localhost:9130/_/proxy/tenants/<tenant_name>/modules
 ```
 
+The module uses system user to communicate with other modules.
+For production deployments you MUST specify the password for this system user via env variable:
+`SYSTEM_USER_PASSWORD=<password>`.
+
 ## Additional information
 
 ### Issue tracker

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -197,6 +197,13 @@
         {
           "methods": ["POST"],
           "pathPattern": "/_/tenant",
+          "modulePermissions": [
+            "users.collection.get",
+            "users.item.post",
+            "login.item.post",
+            "perms.users.item.post",
+            "perms.users.get"
+          ],
           "permissionsRequired": []
         },
         {
@@ -563,6 +570,10 @@
       {
         "name": "DB_MAXPOOLSIZE",
         "value": "5"
+      },
+      {
+        "name": "SYSTEM_USER_PASSWORD",
+        "value": "Mod-innreach-1-0-0"
       }
     ]
   }

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-cache</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
       <exclusions>
         <exclusion>

--- a/src/main/java/org/folio/innreach/ModInnReachApplication.java
+++ b/src/main/java/org/folio/innreach/ModInnReachApplication.java
@@ -2,6 +2,7 @@ package org.folio.innreach;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.scheduling.annotation.EnableAsync;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
@@ -10,6 +11,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 @EnableFeignClients
 @EnableAsync
+@EnableCaching
 public class ModInnReachApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/org/folio/innreach/config/props/SystemUserProperties.java
+++ b/src/main/java/org/folio/innreach/config/props/SystemUserProperties.java
@@ -1,0 +1,19 @@
+package org.folio.innreach.config.props;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("system-user")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SystemUserProperties {
+  private String username;
+  private String password;
+  private String lastname;
+  private String permissionsFilePath;
+}

--- a/src/main/java/org/folio/innreach/controller/FolioTenantController.java
+++ b/src/main/java/org/folio/innreach/controller/FolioTenantController.java
@@ -1,0 +1,37 @@
+package org.folio.innreach.controller;
+
+import lombok.extern.log4j.Log4j2;
+import org.folio.innreach.domain.service.impl.FolioTenantService;
+import org.folio.spring.controller.TenantController;
+import org.folio.spring.service.TenantService;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Log4j2
+@RequestMapping(value = "/_/")
+@RestController("folioTenantController")
+public class FolioTenantController extends TenantController {
+
+  private final FolioTenantService tenantService;
+
+  public FolioTenantController(TenantService baseTenantService, FolioTenantService tenantService) {
+    super(baseTenantService);
+    this.tenantService = tenantService;
+  }
+
+  @Override
+  public ResponseEntity<String> postTenant(TenantAttributes tenantAttributes) {
+    var tenantInit = super.postTenant(tenantAttributes);
+
+    if (tenantInit.getStatusCode() == HttpStatus.OK) {
+      tenantService.initializeTenant();
+    }
+
+    log.info("Tenant init has been completed [response={}]", tenantInit);
+    return tenantInit;
+  }
+
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/FolioExecutionContextBuilder.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/FolioExecutionContextBuilder.java
@@ -1,0 +1,94 @@
+package org.folio.innreach.domain.service.impl;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.With;
+import org.folio.innreach.external.dto.SystemUser;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class FolioExecutionContextBuilder {
+  private final FolioModuleMetadata moduleMetadata;
+
+  public Builder builder() {
+    return new Builder(moduleMetadata);
+  }
+
+  public FolioExecutionContext forSystemUser(SystemUser systemUser) {
+    return builder()
+      .withTenantId(systemUser.getTenantId())
+      .withOkapiUrl(systemUser.getOkapiUrl())
+      .withUsername(systemUser.getUsername())
+      .withToken(systemUser.getToken())
+      .build();
+  }
+
+  public FolioExecutionContext dbOnlyContext(String tenantId) {
+    return builder().withTenantId(tenantId).build();
+  }
+
+  @With
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class Builder {
+    private final FolioModuleMetadata moduleMetadata;
+    private String tenantId;
+    private String okapiUrl;
+    private String token;
+    private String username;
+    private final Map<String, Collection<String>> allHeaders;
+    private final Map<String, Collection<String>> okapiHeaders;
+
+    public Builder(FolioModuleMetadata moduleMetadata) {
+      this.moduleMetadata = moduleMetadata;
+      this.allHeaders = new HashMap<>();
+      this.okapiHeaders = new HashMap<>();
+    }
+
+    public FolioExecutionContext build() {
+      return new FolioExecutionContext() {
+        @Override
+        public String getTenantId() {
+          return tenantId;
+        }
+
+        @Override
+        public String getOkapiUrl() {
+          return okapiUrl;
+        }
+
+        @Override
+        public String getToken() {
+          return token;
+        }
+
+        @Override
+        public String getUserName() {
+          return username;
+        }
+
+        @Override
+        public Map<String, Collection<String>> getAllHeaders() {
+          return allHeaders;
+        }
+
+        @Override
+        public Map<String, Collection<String>> getOkapiHeaders() {
+          return okapiHeaders;
+        }
+
+        @Override
+        public FolioModuleMetadata getFolioModuleMetadata() {
+          return moduleMetadata;
+        }
+      };
+    }
+  }
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/FolioTenantService.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/FolioTenantService.java
@@ -1,0 +1,22 @@
+package org.folio.innreach.domain.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class FolioTenantService {
+
+  private final SystemUserService systemUserService;
+
+  public void initializeTenant() {
+    try {
+      systemUserService.prepareSystemUser();
+    } catch (Exception e) {
+      log.error("Unable to initialize system user", e);
+    }
+  }
+
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/FolioTenantService.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/FolioTenantService.java
@@ -12,11 +12,7 @@ public class FolioTenantService {
   private final SystemUserService systemUserService;
 
   public void initializeTenant() {
-    try {
-      systemUserService.prepareSystemUser();
-    } catch (Exception e) {
-      log.error("Unable to initialize system user", e);
-    }
+    systemUserService.prepareSystemUser();
   }
 
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/SystemUserService.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/SystemUserService.java
@@ -1,0 +1,44 @@
+package org.folio.innreach.domain.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.innreach.config.props.SystemUserProperties;
+import org.folio.innreach.external.dto.SystemUser;
+import org.folio.innreach.external.service.impl.SystemUserAuthService;
+import org.folio.spring.FolioExecutionContext;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Log4j2
+@Service
+@RequiredArgsConstructor
+public class SystemUserService {
+
+  private final SystemUserAuthService authService;
+  private final FolioExecutionContext context;
+  private final SystemUserProperties systemUserConf;
+
+  public void prepareSystemUser() {
+    log.info("Preparing system user...");
+
+    authService.setupSystemUser();
+
+    log.info("System user has been prepared");
+  }
+
+  @Cacheable(cacheNames = "system-user-cache", sync = true)
+  public SystemUser getSystemUser(String tenantId) {
+    log.info("Attempting to issue token for system user [tenantId={}]", tenantId);
+    var systemUser = SystemUser.builder()
+      .tenantId(tenantId)
+      .username(systemUserConf.getUsername())
+      .okapiUrl(context.getOkapiUrl())
+      .build();
+
+    var token = authService.loginSystemUser(systemUser);
+
+    log.info("Token for system user has been issued [tenantId={}]", tenantId);
+    return systemUser.withToken(token);
+  }
+
+}

--- a/src/main/java/org/folio/innreach/domain/service/impl/TenantScopedExecutionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/TenantScopedExecutionService.java
@@ -1,0 +1,41 @@
+package org.folio.innreach.domain.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.folio.spring.FolioExecutionContext;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.Callable;
+
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext;
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.endFolioExecutionContext;
+
+@Service
+@RequiredArgsConstructor
+public class TenantScopedExecutionService {
+  private final FolioExecutionContextBuilder contextBuilder;
+  private final SystemUserService systemUserService;
+
+  /**
+   * Executes given job tenant scoped.
+   *
+   * @param tenantId - The tenant name.
+   * @param job      - Job to be executed in tenant scope.
+   * @param <T>      - Optional return value for the job.
+   * @return Result of job.
+   * @throws RuntimeException - Wrapped exception from the job.
+   */
+  @SneakyThrows
+  public <T> T executeTenantScoped(String tenantId, Callable<T> job) {
+    try {
+      beginFolioExecutionContext(folioExecutionContext(tenantId));
+      return job.call();
+    } finally {
+      endFolioExecutionContext();
+    }
+  }
+
+  private FolioExecutionContext folioExecutionContext(String tenant) {
+    return contextBuilder.forSystemUser(systemUserService.getSystemUser(tenant));
+  }
+}

--- a/src/main/java/org/folio/innreach/external/client/feign/AuthnClient.java
+++ b/src/main/java/org/folio/innreach/external/client/feign/AuthnClient.java
@@ -1,0 +1,28 @@
+package org.folio.innreach.external.client.feign;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.folio.innreach.external.client.feign.config.FolioFeignClientConfig;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@FeignClient(name = "authn", configuration = FolioFeignClientConfig.class)
+public interface AuthnClient {
+
+  @PostMapping(value = "/login", consumes = APPLICATION_JSON_VALUE)
+  ResponseEntity<String> getApiKey(@RequestBody UserCredentials credentials);
+
+  @PostMapping(value = "/credentials", consumes = APPLICATION_JSON_VALUE)
+  void saveCredentials(@RequestBody UserCredentials credentials);
+
+  @Data
+  @AllArgsConstructor(staticName = "of")
+  class UserCredentials {
+    private String username;
+    private String password;
+  }
+}

--- a/src/main/java/org/folio/innreach/external/client/feign/PermissionsClient.java
+++ b/src/main/java/org/folio/innreach/external/client/feign/PermissionsClient.java
@@ -1,0 +1,48 @@
+package org.folio.innreach.external.client.feign;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.folio.innreach.external.client.feign.config.FolioFeignClientConfig;
+import org.folio.innreach.external.dto.ResultList;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@FeignClient(name = "perms/users", configuration = FolioFeignClientConfig.class)
+public interface PermissionsClient {
+
+  @PostMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+  void assignPermissionsToUser(@RequestBody Permissions permissions);
+
+  @PostMapping(value = "/{userId}/permissions?indexField=userId", consumes = APPLICATION_JSON_VALUE)
+  void addPermission(@PathVariable("userId") String userId, Permission permission);
+
+  @GetMapping(value = "/{userId}/permissions?indexField=userId")
+  ResultList<String> getUserPermissions(@PathVariable("userId") String userId);
+
+  @Data
+  @AllArgsConstructor(staticName = "of")
+  @NoArgsConstructor
+  class Permission {
+    private String permissionName;
+  }
+
+  @Data
+  @AllArgsConstructor(staticName = "of")
+  @NoArgsConstructor
+  class Permissions {
+    private String id;
+    private String userId;
+    @JsonProperty("permissions")
+    private List<String> allowedPermissions = Collections.emptyList();
+  }
+}

--- a/src/main/java/org/folio/innreach/external/client/feign/UsersClient.java
+++ b/src/main/java/org/folio/innreach/external/client/feign/UsersClient.java
@@ -1,0 +1,37 @@
+package org.folio.innreach.external.client.feign;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+import org.folio.innreach.external.client.feign.config.FolioFeignClientConfig;
+import org.folio.innreach.external.dto.ResultList;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@FeignClient(name = "users", configuration = FolioFeignClientConfig.class)
+public interface UsersClient {
+  @GetMapping
+  ResultList<User> query(@RequestParam("query") String query);
+
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
+  void saveUser(@RequestBody User user);
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  class User {
+    private String id;
+    private String username;
+    private boolean active;
+    private Personal personal;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Personal {
+      private String lastName;
+    }
+  }
+}

--- a/src/main/java/org/folio/innreach/external/client/feign/config/FolioFeignClientConfig.java
+++ b/src/main/java/org/folio/innreach/external/client/feign/config/FolioFeignClientConfig.java
@@ -1,0 +1,14 @@
+package org.folio.innreach.external.client.feign.config;
+
+import feign.RequestInterceptor;
+import org.folio.spring.FolioExecutionContext;
+import org.springframework.context.annotation.Bean;
+
+public class FolioFeignClientConfig {
+
+  @Bean
+  public RequestInterceptor requestInterceptor(FolioExecutionContext folioExecutionContext) {
+    return new FolioRequestInterceptor(folioExecutionContext);
+  }
+
+}

--- a/src/main/java/org/folio/innreach/external/client/feign/config/FolioRequestInterceptor.java
+++ b/src/main/java/org/folio/innreach/external/client/feign/config/FolioRequestInterceptor.java
@@ -1,0 +1,26 @@
+package org.folio.innreach.external.client.feign.config;
+
+import feign.RequestInterceptor;
+import feign.RequestTemplate;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.folio.spring.FolioExecutionContext;
+
+import java.util.Collections;
+
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
+
+@RequiredArgsConstructor
+public class FolioRequestInterceptor implements RequestInterceptor {
+
+  private final FolioExecutionContext folioExecutionContext;
+
+  @Override
+  @SneakyThrows
+  public void apply(RequestTemplate template) {
+    template.header(TOKEN, Collections.singletonList(folioExecutionContext.getToken()));
+    template.header(TENANT, Collections.singletonList(folioExecutionContext.getTenantId()));
+  }
+
+}

--- a/src/main/java/org/folio/innreach/external/client/feign/config/InnReachFeignClientConfig.java
+++ b/src/main/java/org/folio/innreach/external/client/feign/config/InnReachFeignClientConfig.java
@@ -2,11 +2,9 @@ package org.folio.innreach.external.client.feign.config;
 
 import feign.codec.ErrorDecoder;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import org.folio.innreach.external.client.feign.error.FeignErrorDecoder;
 
-@Configuration
 public class InnReachFeignClientConfig {
 
   @Bean

--- a/src/main/java/org/folio/innreach/external/dto/ResultList.java
+++ b/src/main/java/org/folio/innreach/external/dto/ResultList.java
@@ -1,0 +1,62 @@
+package org.folio.innreach.external.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor(staticName = "of")
+@JsonIgnoreProperties("resultInfo")
+public class ResultList<T> {
+
+  /**
+   * Page number.
+   */
+  @JsonAlias("total_records")
+  private int totalRecords = 0;
+
+  /**
+   * Paged result data.
+   */
+  private List<T> result = Collections.emptyList();
+
+  // The `key` is required per contract
+  @SuppressWarnings("unused")
+  @JsonAnySetter
+  public void set(String key, List<T> result) {
+    this.result = result;
+  }
+
+  /**
+   * Creates empty result list.
+   *
+   * @param <R> generic type for result item.
+   * @return empty result list.
+   */
+  public static <R> ResultList<R> empty() {
+    return new ResultList<>();
+  }
+
+  /**
+   * Creates result list from given resource.
+   *
+   * @param <R> generic type for result item.
+   * @return empty result list.
+   */
+  public static <R> ResultList<R> asSinglePage(List<R> result) {
+    return new ResultList<>(result.size(), result);
+  }
+
+  @SafeVarargs
+  public static <R> ResultList<R> asSinglePage(R... records) {
+    return new ResultList<>(records.length, Arrays.asList(records));
+  }
+}

--- a/src/main/java/org/folio/innreach/external/dto/SystemUser.java
+++ b/src/main/java/org/folio/innreach/external/dto/SystemUser.java
@@ -1,0 +1,15 @@
+package org.folio.innreach.external.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.With;
+
+@Getter
+@Builder
+public class SystemUser {
+  private final String username;
+  @With
+  private final String token;
+  private final String okapiUrl;
+  private final String tenantId;
+}

--- a/src/main/java/org/folio/innreach/external/service/impl/SystemUserAuthService.java
+++ b/src/main/java/org/folio/innreach/external/service/impl/SystemUserAuthService.java
@@ -46,7 +46,7 @@ public class SystemUserAuthService {
       .orElse(UUID.randomUUID().toString());
 
     if (folioUser.isPresent()) {
-      log.info("System user already exists");
+      log.info("Setting up existing system user");
       addPermissions(userId);
     } else {
       log.info("No system user exist, creating...");

--- a/src/main/java/org/folio/innreach/external/service/impl/SystemUserAuthService.java
+++ b/src/main/java/org/folio/innreach/external/service/impl/SystemUserAuthService.java
@@ -1,0 +1,151 @@
+package org.folio.innreach.external.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.log4j.Log4j2;
+import org.apache.commons.io.IOUtils;
+import org.folio.innreach.config.props.SystemUserProperties;
+import org.folio.innreach.domain.service.impl.FolioExecutionContextBuilder;
+import org.folio.innreach.external.client.feign.AuthnClient;
+import org.folio.innreach.external.client.feign.PermissionsClient;
+import org.folio.innreach.external.client.feign.UsersClient;
+import org.folio.innreach.external.dto.SystemUser;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext;
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.endFolioExecutionContext;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+@Log4j2
+@RequiredArgsConstructor
+@Service
+@EnableConfigurationProperties(SystemUserProperties.class)
+public class SystemUserAuthService {
+
+  private final PermissionsClient permissionsClient;
+  private final UsersClient usersClient;
+  private final AuthnClient authnClient;
+  private final FolioExecutionContextBuilder contextBuilder;
+  private final SystemUserProperties folioSystemUserConf;
+
+  public void setupSystemUser() {
+    var folioUser = getFolioUser(folioSystemUserConf.getUsername());
+    var userId = folioUser.map(UsersClient.User::getId)
+      .orElse(UUID.randomUUID().toString());
+
+    if (folioUser.isPresent()) {
+      log.info("System user already exists");
+      addPermissions(userId);
+    } else {
+      log.info("No system user exist, creating...");
+
+      createFolioUser(userId);
+      saveCredentials();
+      assignPermissions(userId);
+    }
+  }
+
+  public String loginSystemUser(SystemUser systemUser) {
+    return executeTenantScoped(contextBuilder.forSystemUser(systemUser), () -> {
+
+      AuthnClient.UserCredentials creds = AuthnClient.UserCredentials
+        .of(systemUser.getUsername(), folioSystemUserConf.getPassword());
+
+      var response = authnClient.getApiKey(creds);
+
+      List<String> tokenHeaders = response.getHeaders().get(XOkapiHeaders.TOKEN);
+
+      return Optional.ofNullable(tokenHeaders)
+        .filter(list -> !CollectionUtils.isEmpty(list))
+        .map(list -> list.get(0))
+        .orElseThrow(() -> new IllegalStateException(String.format("User [%s] cannot log in", systemUser.getUsername())));
+
+    });
+  }
+
+  private Optional<UsersClient.User> getFolioUser(String username) {
+    var users = usersClient.query("username==" + username);
+    return users.getResult().stream().findFirst();
+  }
+
+  private void createFolioUser(String id) {
+    final var user = createUserObject(id);
+    usersClient.saveUser(user);
+  }
+
+  private void saveCredentials() {
+    authnClient.saveCredentials(AuthnClient.UserCredentials.of(folioSystemUserConf.getUsername(), folioSystemUserConf.getPassword()));
+
+    log.info("Saved credentials for user: [{}]", folioSystemUserConf.getUsername());
+  }
+
+  private void assignPermissions(String userId) {
+    List<String> perms = getResourceLines(folioSystemUserConf.getPermissionsFilePath());
+
+    if (isEmpty(perms)) {
+      throw new IllegalStateException("No permissions found to assign to user with id: " + userId);
+    }
+
+    var permissions = PermissionsClient.Permissions.of(UUID.randomUUID()
+      .toString(), userId, perms);
+
+    permissionsClient.assignPermissionsToUser(permissions);
+  }
+
+  private void addPermissions(String userId) {
+    var expectedPermissions = getResourceLines(folioSystemUserConf.getPermissionsFilePath());
+    var assignedPermissions = permissionsClient.getUserPermissions(userId);
+
+    if (isEmpty(expectedPermissions)) {
+      throw new IllegalStateException("No permissions found to assign to user with id: " + userId);
+    }
+
+    var permissionsToAdd = new HashSet<>(expectedPermissions);
+    assignedPermissions.getResult().forEach(permissionsToAdd::remove);
+
+    permissionsToAdd.forEach(permission ->
+      permissionsClient.addPermission(userId, PermissionsClient.Permission.of(permission)));
+  }
+
+  private UsersClient.User createUserObject(String id) {
+    final var user = new UsersClient.User();
+
+    user.setId(id);
+    user.setActive(true);
+    user.setUsername(folioSystemUserConf.getUsername());
+
+    user.setPersonal(new UsersClient.User.Personal());
+    user.getPersonal()
+      .setLastName(folioSystemUserConf.getLastname());
+
+    return user;
+  }
+
+  private <T> T executeTenantScoped(FolioExecutionContext context, Supplier<T> job) {
+    try {
+      beginFolioExecutionContext(context);
+      return job.get();
+    } finally {
+      endFolioExecutionContext();
+    }
+  }
+
+  @SneakyThrows
+  private static List<String> getResourceLines(String permissionsFilePath) {
+    var resource = new ClassPathResource(permissionsFilePath);
+    return IOUtils.readLines(resource.getInputStream(), StandardCharsets.UTF_8);
+  }
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,10 @@ spring:
       accept-single-value-as-array: true
   mustache:
     check-template-location: false
+  cache:
+    cache-names: system-user-cache
+    caffeine:
+      spec: maximumSize=500,expireAfterAccess=3600s
 folio:
   tenant:
     validation:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,10 @@ spring:
     enabled: true
     change-log: classpath:db/changelog/changelog-master.xml
   jackson:
-    default-property-inclusion: NON_EMPTY
+    default-property-inclusion: non_null
+    deserialization:
+      fail-on-unknown-properties: false
+      accept-single-value-as-array: true
   mustache:
     check-template-location: false
 folio:
@@ -56,3 +59,8 @@ inn-reach:
     cache:
       ttl: 500
       max-size: 100
+system-user:
+  username: mod-innreach
+  password: ${SYSTEM_USER_PASSWORD:Mod-innreach-1-0-0}
+  lastname: System
+  permissionsFilePath: permissions/mod-innreach.csv

--- a/src/main/resources/permissions/mod-innreach.csv
+++ b/src/main/resources/permissions/mod-innreach.csv
@@ -1,0 +1,6 @@
+inventory-storage.inventory-view.instances.collection.get
+inventory-storage.instances.collection.get
+inventory-storage.instances.item.get
+inventory-storage.items.collection.get
+inventory-storage.items.item.get
+users.collection.get

--- a/src/test/java/org/folio/innreach/controller/FolioTenantControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/FolioTenantControllerTest.java
@@ -1,0 +1,45 @@
+package org.folio.innreach.controller;
+
+import liquibase.exception.LiquibaseException;
+import org.folio.innreach.domain.service.impl.FolioTenantService;
+import org.folio.spring.service.TenantService;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class FolioTenantControllerTest {
+  private static final TenantAttributes TENANT_ATTRIBUTES = new TenantAttributes()
+    .moduleTo("mod-innreach-1.0.0");
+
+  @Mock
+  private FolioTenantService tenantService;
+  @Mock
+  private TenantService baseTenantService;
+  @InjectMocks
+  private FolioTenantController tenantController;
+
+  @Test
+  void postTenant_shouldCallTenantInitialize() {
+    tenantController.postTenant(TENANT_ATTRIBUTES);
+
+    verify(tenantService).initializeTenant();
+  }
+
+  @Test
+  void postTenant_shouldNotCallTenantInitialize_liquibaseError() throws Exception {
+    doThrow(new LiquibaseException()).when(baseTenantService).createTenant();
+
+    tenantController.postTenant(TENANT_ATTRIBUTES);
+
+    verifyNoInteractions(tenantService);
+  }
+
+}

--- a/src/test/java/org/folio/innreach/domain/service/impl/FolioExecutionContextBuilderTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/FolioExecutionContextBuilderTest.java
@@ -1,0 +1,39 @@
+package org.folio.innreach.domain.service.impl;
+
+import org.folio.innreach.external.dto.SystemUser;
+import org.folio.spring.FolioModuleMetadata;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class FolioExecutionContextBuilderTest {
+  private final FolioExecutionContextBuilder builder =
+    new FolioExecutionContextBuilder(mock(FolioModuleMetadata.class));
+
+  @Test
+  void canCreateDbOnlyContext() {
+    var context = builder.dbOnlyContext("tenant");
+
+    assertThat(context.getTenantId()).isEqualTo("tenant");
+    assertThat(context.getFolioModuleMetadata()).isNotNull();
+  }
+
+  @Test
+  void canCreateSystemUserContext() {
+    var systemUser = SystemUser.builder()
+      .token("token").username("username")
+      .okapiUrl("okapi").tenantId("tenant")
+      .build();
+    var context = builder.forSystemUser(systemUser);
+
+    assertThat(context.getTenantId()).isEqualTo("tenant");
+    assertThat(context.getToken()).isEqualTo("token");
+    assertThat(context.getUserName()).isEqualTo("username");
+    assertThat(context.getOkapiUrl()).isEqualTo("okapi");
+
+    assertThat(context.getAllHeaders()).isNotNull();
+    assertThat(context.getOkapiHeaders()).isNotNull();
+    assertThat(context.getFolioModuleMetadata()).isNotNull();
+  }
+}

--- a/src/test/java/org/folio/innreach/domain/service/impl/FolioTenantServiceTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/FolioTenantServiceTest.java
@@ -6,7 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -34,7 +34,7 @@ class FolioTenantServiceTest {
   void shouldInitializeTenantIfSystemUserInitFailed() {
     doThrow(new RuntimeException("test")).when(systemUserService).prepareSystemUser();
 
-    assertDoesNotThrow(() -> service.initializeTenant());
+    assertThrows(RuntimeException.class, () -> service.initializeTenant());
   }
 
 }

--- a/src/test/java/org/folio/innreach/domain/service/impl/FolioTenantServiceTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/FolioTenantServiceTest.java
@@ -1,0 +1,39 @@
+package org.folio.innreach.domain.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+class FolioTenantServiceTest {
+
+  @Mock
+  private SystemUserService systemUserService;
+
+  @InjectMocks
+  private FolioTenantService service;
+
+  @BeforeEach
+  void setupBeforeEach() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  void shouldInitializeTenant() {
+    service.initializeTenant();
+
+    verify(systemUserService).prepareSystemUser();
+  }
+
+  @Test
+  void shouldInitializeTenantIfSystemUserInitFailed() {
+    doThrow(new RuntimeException("test")).when(systemUserService).prepareSystemUser();
+
+    service.initializeTenant();
+  }
+
+}

--- a/src/test/java/org/folio/innreach/domain/service/impl/FolioTenantServiceTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/FolioTenantServiceTest.java
@@ -6,6 +6,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
@@ -33,7 +34,7 @@ class FolioTenantServiceTest {
   void shouldInitializeTenantIfSystemUserInitFailed() {
     doThrow(new RuntimeException("test")).when(systemUserService).prepareSystemUser();
 
-    service.initializeTenant();
+    assertDoesNotThrow(() -> service.initializeTenant());
   }
 
 }

--- a/src/test/java/org/folio/innreach/domain/service/impl/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/SystemUserServiceTest.java
@@ -1,0 +1,98 @@
+package org.folio.innreach.domain.service.impl;
+
+import org.assertj.core.api.Assertions;
+import org.folio.innreach.config.props.SystemUserProperties;
+import org.folio.innreach.external.dto.SystemUser;
+import org.folio.innreach.external.service.impl.SystemUserAuthService;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.when;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
+
+@Import(SystemUserServiceTest.TestContextConfiguration.class)
+@SpringBootTest(classes = SystemUserService.class, webEnvironment = NONE)
+class SystemUserServiceTest {
+
+  private static final String TENANT_ID = "tenant1";
+  private static final String TENANT2_ID = "tenant2";
+  private static final String AUTH_TOKEN = "aa.bb.cc";
+  private static final String USERNAME = "mod-innreach";
+  private static final String CACHE_NAME = "system-user-cache";
+
+  @Autowired
+  private SystemUserService systemUserService;
+
+  @Autowired
+  private CacheManager cacheManager;
+
+  @MockBean
+  private SystemUserAuthService authService;
+
+
+  @BeforeEach
+  void setupBeforeEach() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  void shouldCreateSystemUser() throws Exception {
+    when(authService.loginSystemUser(Mockito.any(SystemUser.class))).thenReturn(AUTH_TOKEN);
+
+    var systemUser = systemUserService.getSystemUser(TENANT_ID);
+
+    assertThat(systemUser.getTenantId(), is(TENANT_ID));
+    assertThat(systemUser.getToken(), is(AUTH_TOKEN));
+    assertThat(systemUser.getUsername(), is(USERNAME));
+  }
+
+  @Test
+  void shouldCacheToken() {
+    when(authService.loginSystemUser(Mockito.any(SystemUser.class))).thenReturn(AUTH_TOKEN);
+
+    var systemUser = systemUserService.getSystemUser(TENANT2_ID);
+
+    Assertions.assertThat(systemUser).isNotNull();
+    Assertions.assertThat(systemUser.getToken()).isNotNull();
+    Assertions.assertThat(cacheManager.getCache(CACHE_NAME).get(TENANT2_ID, SystemUser.class))
+      .isEqualTo(systemUser);
+  }
+
+  @EnableCaching
+  @TestConfiguration
+  @TestPropertySource("classpath:application.yml")
+  @EnableConfigurationProperties(SystemUserProperties.class)
+  static class TestContextConfiguration {
+
+    @Bean
+    CacheManager cacheManager() {
+      return new ConcurrentMapCacheManager("system-user-cache");
+    }
+
+    @Bean
+    FolioExecutionContext folioExecutionContext() {
+      return new DefaultFolioExecutionContext(null, singletonMap(TENANT, singletonList(TENANT_ID)));
+    }
+  }
+
+}

--- a/src/test/java/org/folio/innreach/domain/service/impl/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/SystemUserServiceTest.java
@@ -8,7 +8,6 @@ import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -27,6 +26,8 @@ import static java.util.Collections.singletonMap;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.NONE;
 
@@ -35,7 +36,6 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 class SystemUserServiceTest {
 
   private static final String TENANT_ID = "tenant1";
-  private static final String TENANT2_ID = "tenant2";
   private static final String AUTH_TOKEN = "aa.bb.cc";
   private static final String USERNAME = "mod-innreach";
   private static final String CACHE_NAME = "system-user-cache";
@@ -56,25 +56,25 @@ class SystemUserServiceTest {
   }
 
   @Test
-  void shouldCreateSystemUser() throws Exception {
-    when(authService.loginSystemUser(Mockito.any(SystemUser.class))).thenReturn(AUTH_TOKEN);
+  void shouldPrepareSystemUser() {
+    systemUserService.prepareSystemUser();
 
-    var systemUser = systemUserService.getSystemUser(TENANT_ID);
-
-    assertThat(systemUser.getTenantId(), is(TENANT_ID));
-    assertThat(systemUser.getToken(), is(AUTH_TOKEN));
-    assertThat(systemUser.getUsername(), is(USERNAME));
+    verify(authService).setupSystemUser();
   }
 
   @Test
-  void shouldCacheToken() {
-    when(authService.loginSystemUser(Mockito.any(SystemUser.class))).thenReturn(AUTH_TOKEN);
+  void shouldGetAndCacheSystemUser() {
+    when(authService.loginSystemUser(any(SystemUser.class))).thenReturn(AUTH_TOKEN);
 
-    var systemUser = systemUserService.getSystemUser(TENANT2_ID);
+    var systemUser = systemUserService.getSystemUser(TENANT_ID);
 
     Assertions.assertThat(systemUser).isNotNull();
     Assertions.assertThat(systemUser.getToken()).isNotNull();
-    Assertions.assertThat(cacheManager.getCache(CACHE_NAME).get(TENANT2_ID, SystemUser.class))
+    assertThat(systemUser.getTenantId(), is(TENANT_ID));
+    assertThat(systemUser.getToken(), is(AUTH_TOKEN));
+    assertThat(systemUser.getUsername(), is(USERNAME));
+
+    Assertions.assertThat(cacheManager.getCache(CACHE_NAME).get(TENANT_ID, SystemUser.class))
       .isEqualTo(systemUser);
   }
 

--- a/src/test/java/org/folio/innreach/external/service/impl/SystemUserAuthServiceTest.java
+++ b/src/test/java/org/folio/innreach/external/service/impl/SystemUserAuthServiceTest.java
@@ -1,0 +1,118 @@
+package org.folio.innreach.external.service.impl;
+
+import org.folio.innreach.config.props.SystemUserProperties;
+import org.folio.innreach.domain.service.impl.FolioExecutionContextBuilder;
+import org.folio.innreach.external.client.feign.AuthnClient;
+import org.folio.innreach.external.client.feign.PermissionsClient;
+import org.folio.innreach.external.client.feign.UsersClient;
+import org.folio.innreach.external.dto.ResultList;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SystemUserAuthServiceTest {
+  @Mock
+  private UsersClient usersClient;
+  @Mock
+  private AuthnClient authnClient;
+  @Mock
+  private PermissionsClient permissionsClient;
+  @Mock
+  private FolioExecutionContextBuilder contextBuilder;
+
+  @Test
+  void shouldCreateSystemUserWhenNotExist() {
+    when(usersClient.query(any())).thenReturn(userNotExistResponse());
+
+    prepareSystemUser(systemUser());
+
+    verify(usersClient).saveUser(any());
+    verify(permissionsClient).assignPermissionsToUser(any());
+  }
+
+  @Test
+  void shouldNotCreateSystemUserWhenExists() {
+    when(usersClient.query(any())).thenReturn(userExistsResponse());
+    when(permissionsClient.getUserPermissions(any())).thenReturn(ResultList.empty());
+
+    prepareSystemUser(systemUser());
+
+    verify(permissionsClient, times(2)).addPermission(any(), any());
+  }
+
+  @Test
+  void cannotUpdateUserIfEmptyPermissions() {
+    var systemUser = systemUserNoPermissions();
+    when(usersClient.query(any())).thenReturn(userNotExistResponse());
+
+    assertThrows(IllegalStateException.class, () -> prepareSystemUser(systemUser));
+
+    verifyNoInteractions(permissionsClient);
+  }
+
+  @Test
+  void cannotCreateUserIfEmptyPermissions() {
+    var systemUser = systemUserNoPermissions();
+    when(usersClient.query(any())).thenReturn(userExistsResponse());
+
+    assertThrows(IllegalStateException.class, () -> prepareSystemUser(systemUser));
+  }
+
+  @Test
+  void shouldAddOnlyNewPermissions() {
+    when(usersClient.query(any())).thenReturn(userExistsResponse());
+    when(permissionsClient.getUserPermissions(any()))
+      .thenReturn(ResultList.asSinglePage("inventory-storage.instance.item.get"));
+
+    prepareSystemUser(systemUser());
+
+    verify(permissionsClient, times(1)).addPermission(any(), any());
+    verify(permissionsClient, times(0))
+      .addPermission(any(), eq(PermissionsClient.Permission.of("inventory-storage.instance.item.get")));
+    verify(permissionsClient, times(1))
+      .addPermission(any(), eq(PermissionsClient.Permission.of("inventory-storage.instance.item.post")));
+  }
+
+  private SystemUserProperties systemUser() {
+    return SystemUserProperties.builder()
+      .password("password")
+      .username("username")
+      .permissionsFilePath("permissions/test-permissions.csv")
+      .build();
+  }
+
+  private SystemUserProperties systemUserNoPermissions() {
+    return SystemUserProperties.builder()
+      .password("password")
+      .username("username")
+      .permissionsFilePath("permissions/empty-permissions.csv")
+      .build();
+  }
+
+  private ResultList<UsersClient.User> userExistsResponse() {
+    return ResultList.asSinglePage(new UsersClient.User());
+  }
+
+  private ResultList<UsersClient.User> userNotExistResponse() {
+    return ResultList.empty();
+  }
+
+  private SystemUserAuthService systemUserService(SystemUserProperties properties) {
+    return new SystemUserAuthService(permissionsClient,
+      usersClient, authnClient, contextBuilder, properties);
+  }
+
+  private void prepareSystemUser(SystemUserProperties properties) {
+    systemUserService(properties).setupSystemUser();
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -28,3 +28,8 @@ inn-reach:
     cache:
       ttl: 500
       max-size: 100
+system-user:
+  username: mod-innreach
+  password: Mod-innreach-1-0-0
+  lastname: System
+  permissionsFilePath: permissions/test-permissions.csv

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -11,6 +11,10 @@ spring:
     show-sql: true
     properties:
       hibernate.format_sql: true
+  cache:
+    cache-names: system-user-cache
+    caffeine:
+      spec: maximumSize=500,expireAfterAccess=3600s
 folio:
   tenant:
     validation:

--- a/src/test/resources/permissions/test-permissions.csv
+++ b/src/test/resources/permissions/test-permissions.csv
@@ -1,0 +1,2 @@
+inventory-storage.instance.item.post
+inventory-storage.instance.item.get


### PR DESCRIPTION
## Purpose
Interaction between Okapi modules is not possible without proper authentication and authorization. Each call should be associated with an authorized requestor. When a call comes from UI it's handled on behalf of real user. In case of Kafka event processing there is no such user. It has to be substituted with internal (system) one.

JIRA: [MODINREACH-118](https://issues.folio.org/browse/MODINREACH-118)

## Approach
- Implement system user creation and login
- Enable system user initialization on tenant init
- Add `TenantScopedExecutionService` that wraps calls which require system user credentials
- Add FOLIO specific feign client configuration allowing to propagate Okapi headers when calling FOLIO modules
- Remove `@Configuration` annotation of `InnReachFeignClientConfig` to make it possible to specify desired configuration per feign client
- Modify default jackson mapping configuration
- Enable caching

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
