### PR TITLE
MODINREACH-113 Bugfix: count number of items linked to an instance

### DIFF
--- a/src/main/java/org/folio/innreach/batch/contribution/service/InstanceLoader.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/InstanceLoader.java
@@ -36,7 +36,7 @@ public class InstanceLoader implements ItemProcessor<InstanceIterationEvent, Ins
         return null;
       }
 
-      // if the returned instance is null it is assumed that processing of the instance should not continue
+      // if the returned instance is null it is assumed that processing of the event should not continue
       var instance = inventoryService.getInstance(instanceIterationEvent.getInstanceId());
 
       if (instance == null) {

--- a/src/test/java/org/folio/innreach/domain/service/impl/InstanceTransformationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/InstanceTransformationServiceImplTest.java
@@ -49,11 +49,9 @@ class InstanceTransformationServiceImplTest {
   }
 
   @Test
-  void shouldGetBibInfo_excludeMultipleStatsCodes() {
+  void shouldGetBibInfo_noItems() {
     Instance instance = createInstance();
-    var item = createItem();
-    item.setStatisticalCodeIds(of(UUID.randomUUID(), UUID.randomUUID()));
-    instance.setItems(of(item));
+    instance.setItems(null);
 
     when(marcService.transformRecord(any(UUID.class), any(Instance.class))).thenReturn(createMARCRecord());
 
@@ -61,7 +59,21 @@ class InstanceTransformationServiceImplTest {
 
     assertNotNull(bibInfo);
     assertEquals(instance.getHrid(), bibInfo.getBibId());
-    assertEquals((Integer) instance.getItems().size(), bibInfo.getItemCount());
+    assertEquals(0, (int) bibInfo.getItemCount());
+  }
+
+  @Test
+  void shouldGetBibInfo_excludeItem() {
+    Instance instance = createInstance();
+
+    when(marcService.transformRecord(any(UUID.class), any(Instance.class))).thenReturn(createMARCRecord());
+    when(validationService.getSuppressionStatus(any(UUID.class), any())).thenReturn('n');
+
+    var bibInfo = service.getBibInfo(CENTRAL_SERVER_ID, instance);
+
+    assertNotNull(bibInfo);
+    assertEquals(instance.getHrid(), bibInfo.getBibId());
+    assertEquals(0, (int) bibInfo.getItemCount());
   }
 
 }

--- a/src/test/java/org/folio/innreach/domain/service/impl/InstanceTransformationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/InstanceTransformationServiceImplTest.java
@@ -1,13 +1,16 @@
 package org.folio.innreach.domain.service.impl;
 
+import static java.util.List.of;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import static org.folio.innreach.fixture.ContributionFixture.createInstance;
+import static org.folio.innreach.fixture.ContributionFixture.createItem;
 import static org.folio.innreach.fixture.ContributionFixture.createMARCRecord;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -35,13 +38,30 @@ class InstanceTransformationServiceImplTest {
 
   @Test
   void shouldGetBibInfo() {
+    Instance instance = createInstance();
+    var bibInfo = service.getBibInfo(CENTRAL_SERVER_ID, instance);
+
     when(marcService.transformRecord(any(UUID.class), any(Instance.class))).thenReturn(createMARCRecord());
 
+    assertNotNull(bibInfo);
+    assertEquals(instance.getHrid(), bibInfo.getBibId());
+    assertEquals((Integer) instance.getItems().size(), bibInfo.getItemCount());
+  }
+
+  @Test
+  void shouldGetBibInfo_excludeMultipleStatsCodes() {
     Instance instance = createInstance();
+    var item = createItem();
+    item.setStatisticalCodeIds(of(UUID.randomUUID(), UUID.randomUUID()));
+    instance.setItems(of(item));
+
+    when(marcService.transformRecord(any(UUID.class), any(Instance.class))).thenReturn(createMARCRecord());
+
     var bibInfo = service.getBibInfo(CENTRAL_SERVER_ID, instance);
 
     assertNotNull(bibInfo);
     assertEquals(instance.getHrid(), bibInfo.getBibId());
+    assertEquals((Integer) instance.getItems().size(), bibInfo.getItemCount());
   }
 
 }

--- a/src/test/java/org/folio/innreach/domain/service/impl/InstanceTransformationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/InstanceTransformationServiceImplTest.java
@@ -1,16 +1,13 @@
 package org.folio.innreach.domain.service.impl;
 
-import static java.util.List.of;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import static org.folio.innreach.fixture.ContributionFixture.createInstance;
-import static org.folio.innreach.fixture.ContributionFixture.createItem;
 import static org.folio.innreach.fixture.ContributionFixture.createMARCRecord;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
@@ -39,9 +36,10 @@ class InstanceTransformationServiceImplTest {
   @Test
   void shouldGetBibInfo() {
     Instance instance = createInstance();
-    var bibInfo = service.getBibInfo(CENTRAL_SERVER_ID, instance);
 
     when(marcService.transformRecord(any(UUID.class), any(Instance.class))).thenReturn(createMARCRecord());
+
+    var bibInfo = service.getBibInfo(CENTRAL_SERVER_ID, instance);
 
     assertNotNull(bibInfo);
     assertEquals(instance.getHrid(), bibInfo.getBibId());


### PR DESCRIPTION
## Purpose
Bugfix for MODINREACH-113

https://issues.folio.org/browse/MODINREACH-113

## Approach
Update bib info service to count linked items that are available for contribution.

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
