### PR TITLE
MODINREACH-148 Fix typo in the permission id for d2ir settings

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -183,7 +183,7 @@
         {
           "methods": ["GET"],
           "pathPattern": "/inn-reach/central-servers/{centralServerId}/d2r/*",
-          "permissionsRequired": ["inn-reach.d2r.settings.any.get"]
+          "permissionsRequired": ["inn-reach.d2ir.settings.any.get"]
         },
         {
           "methods": ["POST"],
@@ -600,7 +600,7 @@
       ]
     },
     {
-      "permissionName" : "inn-reach.d2r.settings.any.get",
+      "permissionName" : "inn-reach.d2ir.settings.any.get",
       "displayName" : "get inn reach settings",
       "description" : "Get inn reach settings"
     },
@@ -924,7 +924,7 @@
         "inn-reach.material-type-mappings.all",
         "inn-reach.library-mappings.all",
         "inn-reach.location-mappings.all",
-        "inn-reach.d2r.settings.any.get",
+        "inn-reach.d2ir.settings.any.get",
         "inn-reach.authentication.all",
         "inn-reach.central-servers.item-contribution-options-configuration.all",
         "inn-reach.agency-mappings.all",


### PR DESCRIPTION
## Purpose
Fix typo in the permission id for: `inn-reach.d2r.settings.any.get`

## Approach
- Rename permission to `inn-reach.d2ir.settings.any.get`

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
