### PR TITLE
MODINREACH-86 Update transaction state to TRANSFER

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -1,5 +1,7 @@
 package org.folio.innreach.domain.service.impl;
 
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.TRANSFER;
+
 import java.util.List;
 import java.util.Objects;
 
@@ -47,6 +49,7 @@ public class CirculationServiceImpl implements CirculationService {
     validateItemIdsEqual(request, transaction);
 
     transaction.getHold().setItemId(request.getNewItemId());
+    transaction.setState(TRANSFER);
 
     return new InnReachResponseDTO().status("ok").reason("success");
   }

--- a/src/test/java/org/folio/innreach/controller/d2ir/TransferRequestCirculationApiTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/TransferRequestCirculationApiTest.java
@@ -11,6 +11,7 @@ import static org.folio.innreach.controller.d2ir.CirculationResultUtils.emptyErr
 import static org.folio.innreach.controller.d2ir.CirculationResultUtils.exceptionMatch;
 import static org.folio.innreach.controller.d2ir.CirculationResultUtils.failedWithReason;
 import static org.folio.innreach.controller.d2ir.CirculationResultUtils.logResponse;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.TRANSFER;
 import static org.folio.innreach.fixture.CirculationFixture.createTransferRequestDTO;
 import static org.folio.innreach.fixture.TestUtil.randomAlphanumeric32Max;
 import static org.folio.innreach.fixture.TestUtil.randomAlphanumeric5;
@@ -65,6 +66,7 @@ class TransferRequestCirculationApiTest extends BaseApiControllerTest {
     var trx = getTransaction(PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
 
     assertEquals(NEW_ITEM_ID, trx.getHold().getItemId());
+    assertEquals(TRANSFER, trx.getState());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Purpose
Update transaction state to TRANSFER upon processing transfer request
JIRA: [MODINREACH-86](https://issues.folio.org/browse/MODINREACH-86)

## Approach
- set transaction state to `TRANSFER` after the item is changed

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
