### PR TITLE
MODINREACH-98 - Return Uncirculated Message for Item Hold

### DIFF
--- a/src/main/java/org/folio/innreach/controller/d2ir/InnReachCirculationController.java
+++ b/src/main/java/org/folio/innreach/controller/d2ir/InnReachCirculationController.java
@@ -2,6 +2,7 @@ package org.folio.innreach.controller.d2ir;
 
 import lombok.RequiredArgsConstructor;
 import org.folio.innreach.dto.BaseCircRequestDTO;
+import org.folio.innreach.dto.ReturnUncirculatedDTO;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -77,6 +78,15 @@ public class InnReachCirculationController implements InnReachCirculationApi {
   public ResponseEntity<InnReachResponseDTO> receiveUnshipped(@PathVariable String trackingId,
     @PathVariable String centralCode, BaseCircRequestDTO receiveUnshippedRequestDTO) {
     var innReachResponse = circulationService.receiveUnshipped(trackingId, centralCode, receiveUnshippedRequestDTO);
+
+    return ResponseEntity.ok(innReachResponse);
+  }
+
+  @Override
+  @PutMapping("/returnuncirculated/{trackingId}/{centralCode}")
+  public ResponseEntity<InnReachResponseDTO> returnUncirculated(@PathVariable String trackingId,
+                                                                @PathVariable String centralCode, ReturnUncirculatedDTO returnUncirculated) {
+    var innReachResponse = circulationService.returnUncirculated(trackingId, centralCode, returnUncirculated);
 
     return ResponseEntity.ok(innReachResponse);
   }

--- a/src/main/java/org/folio/innreach/domain/service/CirculationService.java
+++ b/src/main/java/org/folio/innreach/domain/service/CirculationService.java
@@ -5,6 +5,7 @@ import org.folio.innreach.dto.CancelRequestDTO;
 import org.folio.innreach.dto.InnReachResponseDTO;
 import org.folio.innreach.dto.ItemShippedDTO;
 import org.folio.innreach.dto.PatronHoldDTO;
+import org.folio.innreach.dto.ReturnUncirculatedDTO;
 import org.folio.innreach.dto.TransferRequestDTO;
 
 public interface CirculationService {
@@ -21,4 +22,5 @@ public interface CirculationService {
 
   InnReachResponseDTO receiveUnshipped(String trackingId, String centralCode, BaseCircRequestDTO receiveUnshippedRequestDTO);
 
+  InnReachResponseDTO returnUncirculated(String trackingId, String centralCode, ReturnUncirculatedDTO returnUncirculated);
 }

--- a/src/main/java/org/folio/innreach/domain/service/CirculationService.java
+++ b/src/main/java/org/folio/innreach/domain/service/CirculationService.java
@@ -22,7 +22,8 @@ public interface CirculationService {
 
   InnReachResponseDTO receiveUnshipped(String trackingId, String centralCode, BaseCircRequestDTO receiveUnshippedRequestDTO);
 
+  InnReachResponseDTO itemInTransit(String trackingId, String centralCode, BaseCircRequestDTO itemInTransitRequest);
+
   InnReachResponseDTO returnUncirculated(String trackingId, String centralCode, ReturnUncirculatedDTO returnUncirculated);
 
-  InnReachResponseDTO itemInTransit(String trackingId, String centralCode, BaseCircRequestDTO itemInTransitRequest);
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -8,7 +8,6 @@ import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionSt
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.CANCEL_REQUEST;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_IN_TRANSIT;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RETURN_UNCIRCULATED;

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -187,7 +187,7 @@ public class CirculationServiceImpl implements CirculationService {
   @Override
   public InnReachResponseDTO returnUncirculated(String trackingId, String centralCode, ReturnUncirculatedDTO returnUncirculated) {
     var transaction = getTransaction(trackingId, centralCode);
-    InnReachTransaction.TransactionState state = transaction.getState();
+    var state = transaction.getState();
 
     if (state == ITEM_RECEIVED || state == RECEIVE_UNANNOUNCED) {
       transaction.setState(RETURN_UNCIRCULATED);

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -6,8 +6,10 @@ import static org.apache.commons.lang3.StringUtils.capitalize;
 
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.BORROWING_SITE_CANCEL;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.CANCEL_REQUEST;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RETURN_UNCIRCULATED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.TRANSFER;
 
 import java.util.Objects;
@@ -17,6 +19,7 @@ import java.util.function.Supplier;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.folio.innreach.dto.ReturnUncirculatedDTO;
 import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -179,6 +182,20 @@ public class CirculationServiceImpl implements CirculationService {
     }
 
     return success();
+  }
+
+  @Override
+  public InnReachResponseDTO returnUncirculated(String trackingId, String centralCode, ReturnUncirculatedDTO returnUncirculated) {
+    var transaction = getTransaction(trackingId, centralCode);
+    InnReachTransaction.TransactionState state = transaction.getState();
+
+    if (state == ITEM_RECEIVED || state == RECEIVE_UNANNOUNCED) {
+      transaction.setState(RETURN_UNCIRCULATED);
+      transactionRepository.save(transaction);
+      return success();
+    } else {
+      throw new IllegalArgumentException("Transaction state is not " + ITEM_RECEIVED.name() + " or " + RECEIVE_UNANNOUNCED.name());
+    }
   }
 
   private InnReachResponseDTO success() {

--- a/src/main/resources/swagger.api/circulation.yaml
+++ b/src/main/resources/swagger.api/circulation.yaml
@@ -351,6 +351,35 @@ paths:
       parameters:
               - $ref: '#/components/parameters/trackingId'
               - $ref: '#/components/parameters/centralCode'
+  /d2ir/circ/intransit/{trackingId}/{centralCode}:
+    put:
+      operationId: itemInTransit
+      description: Receives message from central server to owning site indicating that a loaned item is being returned after being loaned to the borrowing patron.
+      tags:
+        - inn-reach-circulation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/baseCircRequestDTO"
+      responses:
+        '200':
+          description: Item in transit message processing complete
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/innReachResponseDTO"
+        '400':
+          description: An error occurred during processing the request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/innReachResponseDTO"
+        '500':
+          $ref: "api-common.yaml#/components/responses/trait_response_500"
+      parameters:
+        - $ref: '#/components/parameters/trackingId'
+        - $ref: '#/components/parameters/centralCode'
   /d2ir/circ/returnuncirculated/{trackingId}/{centralCode}:
     put:
       operationId: returnUncirculated

--- a/src/main/resources/swagger.api/circulation.yaml
+++ b/src/main/resources/swagger.api/circulation.yaml
@@ -351,6 +351,35 @@ paths:
       parameters:
               - $ref: '#/components/parameters/trackingId'
               - $ref: '#/components/parameters/centralCode'
+  /d2ir/circ/returnuncirculated/{trackingId}/{centralCode}:
+    put:
+      operationId: returnUncirculated
+      description: Return uncirculated message for item hold
+      tags:
+        - inn-reach-circulation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/returnUncirculatedDTO"
+      responses:
+        '200':
+          description: Return uncirculated message for item hold request complete
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/innReachResponseDTO"
+        '400':
+          description: An error occurred during processing the request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/innReachResponseDTO"
+        '500':
+          $ref: "api-common.yaml#/components/responses/trait_response_500"
+      parameters:
+        - $ref: '#/components/parameters/trackingId'
+        - $ref: '#/components/parameters/centralCode'
   /transactions:
     get:
       description: Get a list of transactions for the given central server
@@ -439,6 +468,8 @@ components:
       $ref: schemas/patronHoldCheckInResponseDTO.json
     itemHoldCheckOutResponseDTO:
       $ref: schemas/itemHoldCheckOutResponseDTO.json
+    returnUncirculatedDTO:
+      $ref: schemas/d2ir/returnUncirculatedDTO.json
   parameters:
     bibId:
       name: bibId

--- a/src/main/resources/swagger.api/schemas/d2ir/returnUncirculatedDTO.json
+++ b/src/main/resources/swagger.api/schemas/d2ir/returnUncirculatedDTO.json
@@ -1,0 +1,48 @@
+{
+  "description": "INN-Reach Return Circulation Message Put Request Data",
+  "type": "object",
+  "properties": {
+    "transactionTime": {
+      "description": "Transaction time",
+      "type": "integer"
+    },
+    "patronId": {
+      "description": "Patron id",
+      "type": "string",
+      "pattern": "[a-z,0-9]{1,32}"
+    },
+    "patronAgencyCode": {
+      "description": "Patron agency code",
+      "type": "string",
+      "pattern": "[a-z,0-9]{5}"
+    },
+    "itemAgencyCode": {
+      "description": "Item agency code",
+      "type": "string",
+      "pattern": "[a-z,0-9]{5}"
+    },
+    "itemId": {
+      "description": "Item id",
+      "type": "string",
+      "pattern": "[a-z,0-9]{1,32}"
+    },
+    "title": {
+      "description": "Item title",
+      "type": "string",
+      "maxLength": 256
+    },
+    "author": {
+      "description": "Author",
+      "type": "string",
+      "maxLength": 256
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "transactionTime",
+    "patronId",
+    "patronAgencyCode",
+    "itemAgencyCode",
+    "itemId"
+  ]
+}

--- a/src/main/resources/swagger.api/schemas/d2ir/returnUncirculatedDTO.json
+++ b/src/main/resources/swagger.api/schemas/d2ir/returnUncirculatedDTO.json
@@ -1,31 +1,13 @@
 {
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "allOf": [
+    {
+      "$ref": "baseCircRequestDTO.json"
+    }
+  ],
   "description": "INN-Reach Return Circulation Message Put Request Data",
   "type": "object",
   "properties": {
-    "transactionTime": {
-      "description": "Transaction time",
-      "type": "integer"
-    },
-    "patronId": {
-      "description": "Patron id",
-      "type": "string",
-      "pattern": "[a-z,0-9]{1,32}"
-    },
-    "patronAgencyCode": {
-      "description": "Patron agency code",
-      "type": "string",
-      "pattern": "[a-z,0-9]{5}"
-    },
-    "itemAgencyCode": {
-      "description": "Item agency code",
-      "type": "string",
-      "pattern": "[a-z,0-9]{5}"
-    },
-    "itemId": {
-      "description": "Item id",
-      "type": "string",
-      "pattern": "[a-z,0-9]{1,32}"
-    },
     "title": {
       "description": "Item title",
       "type": "string",
@@ -37,12 +19,5 @@
       "maxLength": 256
     }
   },
-  "additionalProperties": false,
-  "required": [
-    "transactionTime",
-    "patronId",
-    "patronAgencyCode",
-    "itemAgencyCode",
-    "itemId"
-  ]
+  "additionalProperties": false
 }

--- a/src/main/resources/swagger.api/schemas/d2ir/returnUncirculatedDTO.json
+++ b/src/main/resources/swagger.api/schemas/d2ir/returnUncirculatedDTO.json
@@ -15,8 +15,7 @@
     },
     "author": {
       "description": "Author",
-      "type": "string",
-      "maxLength": 256
+      "type": "string"
     }
   },
   "additionalProperties": false

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -1,8 +1,11 @@
 package org.folio.innreach.controller.d2ir;
 
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_HOLD;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RETURN_UNCIRCULATED;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.TRANSFER;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -289,6 +292,81 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     var transactionUpdated = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
       PRE_POPULATED_CENTRAL_CODE).get();
     assertNotEquals(RECEIVE_UNANNOUNCED, transactionUpdated.getState());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkTransactionIsInStateItemReceived() {
+    var transactionHoldDTO = createTransactionHoldDTO();
+    var transactionBefore = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
+      PRE_POPULATED_CENTRAL_CODE).get();
+
+    transactionBefore.setState(ITEM_RECEIVED);
+    repository.save(transactionBefore);
+
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
+      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
+      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
+
+    var transactionAfter = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
+      PRE_POPULATED_CENTRAL_CODE).get();
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertEquals(RETURN_UNCIRCULATED, transactionAfter.getState());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkTransactionIsInStateReceiveUnannounced() {
+    var transactionHoldDTO = createTransactionHoldDTO();
+    var transactionBefore = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
+      PRE_POPULATED_CENTRAL_CODE).get();
+
+    transactionBefore.setState(RECEIVE_UNANNOUNCED);
+    repository.save(transactionBefore);
+
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
+      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
+      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
+
+    var transactionAfter = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
+      PRE_POPULATED_CENTRAL_CODE).get();
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertEquals(RETURN_UNCIRCULATED, transactionAfter.getState());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkTransactionIsNotInStateItemReceivedOrReceiveUnannounced() {
+    var transactionHoldDTO = createTransactionHoldDTO();
+    var transactionBefore = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
+      PRE_POPULATED_CENTRAL_CODE).get();
+
+    transactionBefore.setState(TRANSFER);
+    repository.save(transactionBefore);
+
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
+      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
+      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
+
+    var transactionAfter = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
+      PRE_POPULATED_CENTRAL_CODE).get();
+
+    assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+    assertEquals(TRANSFER, transactionAfter.getState());
   }
 
 }

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -20,13 +20,9 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.OK;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
-
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.BORROWING_SITE_CANCEL;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_HOLD;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_IN_TRANSIT;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
 import static org.folio.innreach.fixture.CirculationFixture.createItemShippedDTO;
 import static org.folio.innreach.fixture.CirculationFixture.createTransactionHoldDTO;
 
@@ -48,7 +44,6 @@ import org.springframework.test.context.jdbc.SqlMergeMode;
 
 import org.folio.innreach.controller.base.BaseControllerTest;
 import org.folio.innreach.domain.dto.folio.inventory.InventoryItemDTO;
-import org.folio.innreach.domain.entity.InnReachTransaction;
 import org.folio.innreach.domain.service.InventoryService;
 import org.folio.innreach.domain.service.RequestService;
 import org.folio.innreach.dto.InnReachResponseDTO;
@@ -299,32 +294,6 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     assertNotEquals(RECEIVE_UNANNOUNCED, transactionUpdated.getState());
   }
 
-  @ParameterizedTest
-  @EnumSource(names = {"ITEM_RECEIVED","RECEIVE_UNANNOUNCED"})
-  @Sql(scripts = {
-    "classpath:db/central-server/pre-populate-central-server.sql",
-    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
-  })
-  void checkTransactionIsInStateItemReceivedOrReceiveUnannounced(InnReachTransaction.TransactionState testEnums) {
-    var transactionHoldDTO = createTransactionHoldDTO();
-    var transactionBefore = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
-      PRE_POPULATED_CENTRAL_CODE).get();
-
-    transactionBefore.setState(testEnums);
-    repository.save(transactionBefore);
-
-    var responseEntity = testRestTemplate.exchange(
-      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
-      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
-      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
-
-    var transactionAfter = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
-      PRE_POPULATED_CENTRAL_CODE).get();
-
-    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-    assertEquals(RETURN_UNCIRCULATED, transactionAfter.getState());
-  }
-
   @Test
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",
@@ -356,31 +325,6 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
   })
-  void checkTransactionIsNotInStateItemReceivedOrReceiveUnannounced() {
-    var transactionHoldDTO = createTransactionHoldDTO();
-    var transactionBefore = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
-      PRE_POPULATED_CENTRAL_CODE).get();
-
-    transactionBefore.setState(TRANSFER);
-    repository.save(transactionBefore);
-
-    var responseEntity = testRestTemplate.exchange(
-      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
-      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
-      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
-
-    var transactionAfter = repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID,
-      PRE_POPULATED_CENTRAL_CODE).get();
-
-    assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
-    assertEquals(TRANSFER, transactionAfter.getState());
-  }
-
-  @Test
-  @Sql(scripts = {
-    "classpath:db/central-server/pre-populate-central-server.sql",
-    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
-  })
   void processItemInTransit_unexpectedTransactionState() {
     var transaction = fetchPrePopulatedTransaction();
     transaction.setState(ITEM_HOLD);
@@ -405,6 +349,53 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
 
   private InnReachTransaction fetchPrePopulatedTransaction() {
     return repository.findByTrackingIdAndCentralServerCode(PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE).get();
+  }
+
+  @ParameterizedTest
+  @EnumSource(names = {"ITEM_RECEIVED","RECEIVE_UNANNOUNCED"})
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkTransactionIsInStateItemReceivedOrReceiveUnannounced(InnReachTransaction.TransactionState testEnums) {
+    var transactionHoldDTO = createTransactionHoldDTO();
+    var transactionBefore = fetchPrePopulatedTransaction();
+
+    transactionBefore.setState(testEnums);
+    repository.save(transactionBefore);
+
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
+      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
+      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
+
+    var transactionAfter = fetchPrePopulatedTransaction();
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertEquals(RETURN_UNCIRCULATED, transactionAfter.getState());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkTransactionIsNotInStateItemReceivedOrReceiveUnannounced() {
+    var transactionHoldDTO = createTransactionHoldDTO();
+    var transactionBefore = fetchPrePopulatedTransaction();
+
+    transactionBefore.setState(TRANSFER);
+    repository.save(transactionBefore);
+
+    var responseEntity = testRestTemplate.exchange(
+      "/inn-reach/d2ir/circ/returnuncirculated/{trackingId}/{centralCode}", HttpMethod.PUT,
+      new HttpEntity<>(transactionHoldDTO), InnReachResponseDTO.class,
+      PRE_POPULATED_TRACKING_ID, PRE_POPULATED_CENTRAL_CODE);
+
+    var transactionAfter = fetchPrePopulatedTransaction();
+
+    assertEquals(HttpStatus.BAD_REQUEST, responseEntity.getStatusCode());
+    assertEquals(TRANSFER, transactionAfter.getState());
   }
 
 }

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -22,11 +22,8 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.BORROWING_SITE_CANCEL;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_HOLD;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_IN_TRANSIT;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
 import static org.folio.innreach.fixture.CirculationFixture.createItemShippedDTO;
 import static org.folio.innreach.fixture.CirculationFixture.createTransactionHoldDTO;
 
@@ -48,7 +45,6 @@ import org.springframework.test.context.jdbc.SqlMergeMode;
 
 import org.folio.innreach.controller.base.BaseControllerTest;
 import org.folio.innreach.domain.dto.folio.inventory.InventoryItemDTO;
-import org.folio.innreach.domain.entity.InnReachTransaction;
 import org.folio.innreach.domain.service.InventoryService;
 import org.folio.innreach.domain.service.RequestService;
 import org.folio.innreach.dto.InnReachResponseDTO;


### PR DESCRIPTION
[MODINREACH-98](https://issues.folio.org/browse/MODINREACH-98) - Return Uncirculated Message for Item Hold

## Purpose
Endpoint receives message from central server to owning site indicating that an item that was checked out to and received by the borrowing site (shipped) is being returned by the borrowing site without being checked out by the requesting patron.

## Approach
Local endpoint implemented
Tests added

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
