### PR TITLE
Add support of text/plain representation for json data

### DIFF
--- a/src/main/java/org/folio/innreach/converter/InnReachTextJsonHttpMessageConverter.java
+++ b/src/main/java/org/folio/innreach/converter/InnReachTextJsonHttpMessageConverter.java
@@ -15,6 +15,7 @@ public class InnReachTextJsonHttpMessageConverter extends MappingJackson2HttpMes
     super(objectMapper);
     var mediaTypeList = new ArrayList<>(this.getSupportedMediaTypes());
     mediaTypeList.add(new MediaType("text", "json", StandardCharsets.UTF_8));
+    mediaTypeList.add(new MediaType("text", "plain", StandardCharsets.UTF_8));
     this.setSupportedMediaTypes(mediaTypeList);
   }
 


### PR DESCRIPTION
## Purpose
For some reason the (FOLIO) UI framework expects plain text (`accept: text/plain`) data as a response of PUT requests and it works this way with other back-end modules. Adding support of text/plain representation for json converter seems to be the easiest workaround to solve the problem on our end.

## Approach
- Add support of text/plain representation to `InnReachTextJsonHttpMessageConverter`

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
