### PR TITLE
MODINREACH-93 Disable JPA transaction on init patron/local hold

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/RequestService.java
+++ b/src/main/java/org/folio/innreach/domain/service/RequestService.java
@@ -18,7 +18,7 @@ public interface RequestService {
   void createItemHoldRequest(String transactionTrackingId);
 
   @Async
-  void createLocalHoldRequest(String transactionTrackingId);
+  void createLocalHoldRequest(InnReachTransaction transaction);
 
   void createItemRequest(InnReachTransaction transaction, Holding holding, InventoryItemDTO item,
                          User patron, UUID servicePointId, RequestType requestType);

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -103,6 +103,7 @@ public class CirculationServiceImpl implements CirculationService {
       var existingTransaction = optTransaction.get();
 
       updateTransactionHold(existingTransaction.getHold(), transactionHold);
+      existingTransaction = transactionRepository.save(existingTransaction);
 
       patronHoldService.updateVirtualItems(existingTransaction);
     } else {
@@ -110,7 +111,6 @@ public class CirculationServiceImpl implements CirculationService {
         trackingId, centralCode);
 
       var newTransaction = createTransaction(trackingId, centralCode, transactionHold, TransactionType.PATRON);
-
       newTransaction = transactionRepository.save(newTransaction);
 
       patronHoldService.createVirtualItems(newTransaction);

--- a/src/main/java/org/folio/innreach/domain/service/impl/RequestServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/RequestServiceImpl.java
@@ -126,8 +126,7 @@ public class RequestServiceImpl implements RequestService {
 
   @Async
   @Override
-  public void createLocalHoldRequest(String trackingId) {
-    var transaction = fetchTransactionByTrackingId(trackingId);
+  public void createLocalHoldRequest(InnReachTransaction transaction) {
     var hold = (TransactionLocalHold) transaction.getHold();
     var centralPatronName = hold.getPatronName();
     try {


### PR DESCRIPTION
## Purpose
Disable JPA transaction on patron/local hold creation as it prevents to save an entity manually before executing async step for request creation.

## Approach
- Change propagation type to NEVER
- Minor refactoring

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
