### PR TITLE
MODINREACh-221 - Fix Initial record contribution event consuming

### DIFF
--- a/src/main/java/org/folio/innreach/batch/KafkaItemReader.java
+++ b/src/main/java/org/folio/innreach/batch/KafkaItemReader.java
@@ -30,7 +30,7 @@ public class KafkaItemReader<K, V> implements AutoCloseable {
   private static final long DEFAULT_POLL_TIMEOUT = 30L;
 
   private final Properties consumerProperties;
-  private final List<TopicPartition> topicPartitions;
+  private final String topic;
 
   private Map<TopicPartition, Long> partitionOffsets;
   private KafkaConsumer<K, V> kafkaConsumer;
@@ -43,8 +43,7 @@ public class KafkaItemReader<K, V> implements AutoCloseable {
       kafkaConsumer = new KafkaConsumer<>(consumerProperties);
     }
 
-    kafkaConsumer.assign(topicPartitions);
-    partitionOffsets.forEach(kafkaConsumer::seek);
+    kafkaConsumer.subscribe(List.of(topic));
   }
 
   public V read() {

--- a/src/main/java/org/folio/innreach/batch/KafkaItemReader.java
+++ b/src/main/java/org/folio/innreach/batch/KafkaItemReader.java
@@ -1,6 +1,7 @@
 package org.folio.innreach.batch;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -31,8 +32,8 @@ public class KafkaItemReader<K, V> implements AutoCloseable {
 
   private final Properties consumerProperties;
   private final String topic;
+  private final Map<TopicPartition, Long> partitionOffsets = new HashMap<>();
 
-  private Map<TopicPartition, Long> partitionOffsets;
   private KafkaConsumer<K, V> kafkaConsumer;
   private Iterator<ConsumerRecord<K, V>> consumerRecords;
   private Consumer<ConsumerRecord<K, V>> recordProcessor;

--- a/src/main/java/org/folio/innreach/batch/contribution/IterationEventReaderFactory.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/IterationEventReaderFactory.java
@@ -1,6 +1,6 @@
 package org.folio.innreach.batch.contribution;
 
-import static java.util.List.of;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -10,7 +10,6 @@ import java.util.function.Consumer;
 
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.TopicPartition;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
 import org.springframework.stereotype.Component;
 
@@ -40,11 +39,12 @@ public class IterationEventReaderFactory {
   public KafkaItemReader<String, InstanceIterationEvent> createReader(String tenantId) {
     Properties props = new Properties();
     props.putAll(kafkaProperties.buildConsumerProperties());
+    props.put(GROUP_ID_CONFIG, jobProperties.getReaderGroupId());
 
     var topic = String.format("%s.%s.%s",
       folioEnv.getEnvironment(), tenantId, jobProperties.getReaderTopic());
 
-    var reader = new KafkaItemReader<String, InstanceIterationEvent>(props, of(new TopicPartition(topic, 0)));
+    var reader = new KafkaItemReader<String, InstanceIterationEvent>(props, topic);
     reader.setPollTimeout(Duration.ofSeconds(jobProperties.getReaderPollTimeoutSec()));
     reader.setPartitionOffsets(new HashMap<>());
     reader.setRecordProcessor(CONSUMER_REC_PROCESSOR);

--- a/src/main/java/org/folio/innreach/batch/contribution/IterationEventReaderFactory.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/IterationEventReaderFactory.java
@@ -46,7 +46,6 @@ public class IterationEventReaderFactory {
 
     var reader = new KafkaItemReader<String, InstanceIterationEvent>(props, topic);
     reader.setPollTimeout(Duration.ofSeconds(jobProperties.getReaderPollTimeoutSec()));
-    reader.setPartitionOffsets(new HashMap<>());
     reader.setRecordProcessor(CONSUMER_REC_PROCESSOR);
     return reader;
   }

--- a/src/main/java/org/folio/innreach/config/props/ContributionJobProperties.java
+++ b/src/main/java/org/folio/innreach/config/props/ContributionJobProperties.java
@@ -11,6 +11,7 @@ public class ContributionJobProperties {
   private int retryIntervalMs = 1000;
   private int retryAttempts = 3;
   private String readerTopic;
+  private String readerGroupId;
   private long readerPollTimeoutSec;
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -116,6 +116,7 @@ batch:
       retry-attempts: 3
       retry-interval-ms: 20000
       reader-topic: inventory.instance-contribution
+      reader-group-id: ${ENV:folio}-mod-innreach-contribution-events-group
       reader-poll-timeout-sec: 300
 reference-data:
   loader:

--- a/src/test/java/org/folio/innreach/batch/contribution/IterationEventReaderFactoryTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/IterationEventReaderFactoryTest.java
@@ -2,6 +2,7 @@ package org.folio.innreach.batch.contribution;
 
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +29,8 @@ class IterationEventReaderFactoryTest {
 
   @Test
   void createReader() {
+    when(jobProperties.getReaderGroupId()).thenReturn("topic");
+
     var reader = factory.createReader("test");
 
     assertNotNull(reader);

--- a/src/test/java/org/folio/innreach/batch/contribution/service/KafkaItemReaderTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/KafkaItemReaderTest.java
@@ -5,27 +5,23 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
 import static org.folio.innreach.batch.contribution.IterationEventReaderFactory.CONSUMER_REC_PROCESSOR;
 import static org.folio.innreach.batch.contribution.IterationEventReaderFactory.ITERATION_JOB_ID_HEADER;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.Properties;
 import java.util.UUID;
-import java.util.function.BiConsumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.folio.innreach.batch.KafkaItemReader;
@@ -34,27 +30,17 @@ import org.folio.innreach.domain.dto.folio.inventorystorage.InstanceIterationEve
 @ExtendWith(MockitoExtension.class)
 class KafkaItemReaderTest {
 
-  @Spy
-  private List<TopicPartition> topicPartitions;
-
-  @Spy
-  private Map<TopicPartition, Long> partitionOffsets;
-
   @Mock(answer = Answers.RETURNS_DEEP_STUBS)
   private KafkaConsumer<String, InstanceIterationEvent> kafkaConsumer;
 
   @Mock
   private Iterator<ConsumerRecord<String, InstanceIterationEvent>> consumerRecords;
 
-  @Mock
-  private BiConsumer<String, InstanceIterationEvent> consumer;
-
   @InjectMocks
-  private KafkaItemReader<String, InstanceIterationEvent> reader;
+  private KafkaItemReader<String, InstanceIterationEvent> reader = new KafkaItemReader<>(new Properties(), "topic");
 
   @BeforeEach
   void setUp() {
-    openMocks(this);
     reader.setRecordProcessor(CONSUMER_REC_PROCESSOR);
   }
 
@@ -62,14 +48,7 @@ class KafkaItemReaderTest {
   void shouldOpen() {
     reader.open();
 
-    verify(kafkaConsumer).assign(topicPartitions);
-  }
-
-  @Test
-  void shouldInitConsumerWhenOpen() {
-    reader.open();
-
-    verify(kafkaConsumer).assign(topicPartitions);
+    verify(kafkaConsumer).subscribe(any(List.class));
   }
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -45,12 +45,4 @@ system-user:
   password: Mod-innreach-1-0-0
   lastname: System
   permissionsFilePath: permissions/test-permissions.csv
-batch:
-  jobs:
-    contribution:
-      chunk-size: 1
-      retry-attempts: 3
-      retry-interval-ms: 20000
-      reader-topic: folio.diku.inventory.instance-contribution
-      reader-poll-timeout-sec: 300
 okapi.url: ${OKAPI_URL:http://localhost:8080}


### PR DESCRIPTION
## Purpose
Fix Initial record contribution event consuming

## Approach
- Add unique group id for the reader 
- Subscribe kafka reader to a topic instead of assigning a certain partition
- Update tests

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
