### PR TITLE
MODINREACH-257 - Unnecessary Cancel Request Call to Central Server

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -251,8 +251,10 @@ public class CirculationServiceImpl implements CirculationService {
     if (transaction.getHold().getFolioLoanId() != null) {
       throw new IllegalArgumentException("Requested item is already checked out.");
     }
-    requestService.cancelRequest(transaction, "Request cancelled at borrowing site");
+
     transaction.setState(BORROWING_SITE_CANCEL);
+
+    requestService.cancelRequest(transaction, "Request cancelled at borrowing site");
 
     return success();
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -256,8 +256,8 @@ public class CirculationServiceImpl implements CirculationService {
 
     // the state should be updated before cancelRequest called as the transaction should be in a proper state when
     // kafka event for a request update is consumed after the cancellation
-    transactionRepository.saveAndFlush(transaction);
     transaction.setState(BORROWING_SITE_CANCEL);
+    transactionRepository.saveAndFlush(transaction);
 
     requestService.cancelRequest(transaction, "Request cancelled at borrowing site");
 

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -332,9 +333,10 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     assertNotNull(responseEntityBody);
     assertEquals("ok", responseEntityBody.getStatus());
 
-    verify(requestService).cancelRequest(any(), eq("Request cancelled at borrowing site"));
-    var transactionUpdated = fetchTransactionByTrackingId(PRE_POPULATED_TRACKING2_ID);
-    assertEquals(BORROWING_SITE_CANCEL, transactionUpdated.getState());
+    var inOrder = inOrder(transactionRepository, requestService);
+
+    inOrder.verify(transactionRepository).saveAndFlush(argThat(t -> t.getState() == BORROWING_SITE_CANCEL));
+    inOrder.verify(requestService).cancelRequest(any(), eq("Request cancelled at borrowing site"));
   }
 
   @Test


### PR DESCRIPTION
## Purpose
After a borrowing site cancel message is received by mod-inn-reach, the FOLIO request for the item is cancelled, and this is triggering an errant "owning site cancel" call. The "borrowing site cancel" message is a terminating transaction and no subsequent messages should be sent for the associated transaction.

https://issues.folio.org/browse/MODINREACH-257

## Approach
- Update transaction state to `BORROWING_SITE_CANCEL` before performing request cancellation

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
