### PR TITLE
MODINREACH-248,251 - FIX

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -431,9 +431,7 @@ public class CirculationServiceImpl implements CirculationService {
     loanService.claimItemReturned(folioLoanId, returnedDate);
 
     transaction.setState(CLAIMS_RETURNED);
-    var itemHold = transaction.getHold();
-    itemHold.setPatronId(null);
-    itemHold.setPatronName(null);
+    clearCentralPatronInfo(transaction);
 
     return success();
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -284,11 +284,11 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     log.info("Updating patron transaction {} on the claimed returned loan {}", transaction.getId(), loan.getId());
 
     transaction.setState(CLAIMS_RETURNED);
-    clearPatronAndItemInfo(transaction);
 
     var claimedReturnedDateSec = ofNullable(loan.getClaimedReturnedDate()).map(DateHelper::toEpochSec).orElse(-1);
 
     notifier.reportClaimsReturned(transaction, claimedReturnedDateSec);
+    clearPatronAndItemInfo(transaction);
   }
 
   private void updateTransactionOnLoanRenewal(StorageLoanDTO loan, InnReachTransaction transaction) {
@@ -383,10 +383,9 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
       transaction.setState(CANCEL_REQUEST);
 
-      clearCentralPatronInfo(transaction);
-
       var instance = instanceStorageClient.getInstanceById(requestDTO.getInstanceId());
       notifier.reportOwningSiteCancel(transaction, instance.getHrid(), hold.getPatronName());
+      clearCentralPatronInfo(transaction);
     } else if (!itemId.equals(hold.getFolioItemId())) {
       log.info("Updating transaction {} on moving a request {} from one item to another", transaction.getId(), requestId);
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -288,7 +288,8 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     var claimedReturnedDateSec = ofNullable(loan.getClaimedReturnedDate()).map(DateHelper::toEpochSec).orElse(-1);
 
     notifier.reportClaimsReturned(transaction, claimedReturnedDateSec);
-    clearPatronAndItemInfo(transaction);
+
+    clearPatronAndItemInfo(transaction.getHold());
   }
 
   private void updateTransactionOnLoanRenewal(StorageLoanDTO loan, InnReachTransaction transaction) {
@@ -383,10 +384,9 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
       transaction.setState(CANCEL_REQUEST);
 
-      clearCentralPatronInfo(transaction);
-
       var instance = instanceStorageClient.getInstanceById(requestDTO.getInstanceId());
       notifier.reportOwningSiteCancel(transaction, instance.getHrid(), hold.getPatronName());
+
       clearCentralPatronInfo(transaction);
     } else if (!itemId.equals(hold.getFolioItemId())) {
       log.info("Updating transaction {} on moving a request {} from one item to another", transaction.getId(), requestId);

--- a/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -29,6 +30,7 @@ import static org.folio.innreach.util.DateHelper.toEpochSec;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -92,6 +94,7 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
   private static final UUID PRE_POPULATED_ITEM_TRANSACTION_LOAN_ID = UUID.fromString("06e820e3-71a0-455e-8c73-3963aea677d4");
   private static final UUID PRE_POPULATED_LOCAL_TRANSACTION_ID = UUID.fromString("79b0a1fb-55be-4e55-9d84-01303aaec1ce");
   private static final String TEST_TENANT_ID = "testing";
+  private static final String TEST_PATRON_NAME = "patronName2";
   private static final Duration ASYNC_AWAIT_TIMEOUT = Duration.ofSeconds(15);
   private static final Date DUE_DATE = new Date();
   private static final UUID CHECKIN_ID = UUID.randomUUID();
@@ -409,13 +412,18 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
     request.setInstanceId(INSTANCE_ID);
     request.setStatus(CLOSED_CANCELLED);
 
+    var payload = new HashMap<>();
+    payload.put("localBibId", instance.getHrid());
+    payload.put("reasonCode", 7);
+    payload.put("patronName", TEST_PATRON_NAME);
+
     when(instanceStorageClient.getInstanceById(request.getInstanceId())).thenReturn(instance);
 
     listener.handleRequestEvents(asSingleConsumerRecord(CIRC_REQUEST_TOPIC, REQUEST_ID, event));
 
     verify(eventProcessor).process(anyList(), any(Consumer.class));
     verify(instanceStorageClient, times(1)).getInstanceById(any());
-    verify(innReachExternalService, times(1)).postInnReachApi(any(), any(), any());
+    verify(innReachExternalService, times(1)).postInnReachApi(any(), any(), eq(payload));
     Mockito.verifyNoMoreInteractions(itemService);
 
     var updatedTransaction = transactionRepository.fetchOneById(PRE_POPULATED_ITEM_TRANSACTION_ID).orElse(null);


### PR DESCRIPTION
[MODINREACH-248](https://issues.folio.org/browse/MODINREACH-248)
[MODINREACH-251](https://issues.folio.org/browse/MODINREACH-251)

## Purpose
The story specifies that the owningsitecancel message be sent to the central server successfully before the identifying information is removed. The sequencing seems to be wrong, and the cancel is failing because required information is not being sent to the central.

## Approach
Fixed order operations

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?