### PR TITLE
MODINREACH-249  INN-Reach Circulation Flow Terminating Transaction Handling: Local Checkout (Patron Hold)

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -250,7 +250,7 @@ public class CirculationServiceImpl implements CirculationService {
     // kafka event for a request update is consumed after the cancellation
     transaction.setState(BORROWING_SITE_CANCEL);
 
-    clearCentralPatronInfo(transaction);
+    clearCentralPatronInfo(transaction.getHold());
 
     transaction = saveAndPersist(transaction);
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -269,11 +269,15 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
   private void associateNewLoanWithLocalTransaction(StorageLoanDTO loan, InnReachTransaction transaction) {
     log.info("Associating a new loan {} with local transaction {}", loan.getId(), transaction.getId());
+
     var hold = transaction.getHold();
     hold.setFolioLoanId(loan.getId());
     transaction.setState(LOCAL_CHECKOUT);
+
     var inventoryItemDTO = fetchItemById(loan.getItemId());
     notifier.reportCheckOut(transaction, inventoryItemDTO.getHrid(), inventoryItemDTO.getBarcode());
+
+    clearPatronAndItemInfo(hold);
   }
 
   private void updateTransactionOnLoanClaimedReturned(StorageLoanDTO loan, InnReachTransaction transaction) {
@@ -317,7 +321,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
       hold.setDueDateTime(null);
 
-      clearCentralPatronInfo(transaction);
+      clearCentralPatronInfo(transaction.getHold());
 
       transaction.setState(FINAL_CHECKIN);
 
@@ -383,7 +387,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
       transaction.setState(CANCEL_REQUEST);
 
-      clearCentralPatronInfo(transaction);
+      clearCentralPatronInfo(transaction.getHold());
 
       var instance = instanceStorageClient.getInstanceById(requestDTO.getInstanceId());
       notifier.reportOwningSiteCancel(transaction, instance.getHrid(), hold.getPatronName());

--- a/src/main/java/org/folio/innreach/util/InnReachTransactionUtils.java
+++ b/src/main/java/org/folio/innreach/util/InnReachTransactionUtils.java
@@ -1,11 +1,12 @@
 package org.folio.innreach.util;
 
 import lombok.experimental.UtilityClass;
+
 import org.apache.commons.lang3.ArrayUtils;
-import org.folio.innreach.domain.entity.TransactionHold;
 import org.springframework.util.Assert;
 
 import org.folio.innreach.domain.entity.InnReachTransaction;
+import org.folio.innreach.domain.entity.TransactionHold;
 
 @UtilityClass
 public class InnReachTransactionUtils {
@@ -28,9 +29,9 @@ public class InnReachTransactionUtils {
     hold.setFolioItemBarcode(null);
   }
 
-  public static void clearCentralPatronInfo(InnReachTransaction transaction) {
-    var hold = transaction.getHold();
+  public static void clearCentralPatronInfo(TransactionHold hold) {
     hold.setPatronId(null);
     hold.setPatronName(null);
   }
+
 }

--- a/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
@@ -1,7 +1,6 @@
 package org.folio.innreach.domain.listener;
 
 import static org.awaitility.Awaitility.await;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.LOCAL_CHECKOUT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -20,6 +19,7 @@ import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionSt
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.FINAL_CHECKIN;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_IN_TRANSIT;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.LOCAL_CHECKOUT;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECALL;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RETURN_UNCIRCULATED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.TRANSFER;
@@ -51,6 +51,7 @@ import org.folio.innreach.client.InstanceStorageClient;
 import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
 import org.folio.innreach.domain.dto.folio.inventory.InventoryItemDTO;
 import org.folio.innreach.domain.entity.InnReachTransaction;
+import org.folio.innreach.domain.entity.TransactionHold;
 import org.folio.innreach.domain.entity.TransactionItemHold;
 import org.folio.innreach.domain.event.DomainEvent;
 import org.folio.innreach.domain.event.DomainEventType;
@@ -216,6 +217,8 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
     var updatedTransaction = transactionRepository.fetchOneById(PRE_POPULATED_LOCAL_TRANSACTION_ID).orElseThrow();
     assertEquals(PRE_POPULATED_LOCAL_LOAN_ID, updatedTransaction.getHold().getFolioLoanId());
     assertEquals(LOCAL_CHECKOUT, updatedTransaction.getState());
+
+    assertPatronAndItemInfoCleared(updatedTransaction.getHold());
   }
 
   @Test
@@ -288,17 +291,10 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
     var payload = payloadCaptor.getValue();
     var updatedTransaction = transactionRepository.fetchOneById(PRE_POPULATED_PATRON_TRANSACTION_ID).orElseThrow();
     assertEquals(CLAIMS_RETURNED, updatedTransaction.getState());
+
     var itemHold = updatedTransaction.getHold();
-    assertNull(itemHold.getPatronId());
-    assertNull(itemHold.getPatronName());
-    assertNull(itemHold.getFolioPatronId());
-    assertNull(itemHold.getFolioPatronBarcode());
-    assertNull(itemHold.getFolioItemId());
-    assertNull(itemHold.getFolioHoldingId());
-    assertNull(itemHold.getFolioInstanceId());
-    assertNull(itemHold.getFolioRequestId());
-    assertNull(itemHold.getFolioLoanId());
-    assertNull(itemHold.getFolioItemBarcode());
+    assertPatronAndItemInfoCleared(itemHold);
+
     assertEquals(toEpochSec(claimedReturnedDate), payload.get("claimsReturnedDate"));
   }
 
@@ -323,9 +319,9 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
     var updatedTransaction = transactionRepository.fetchOneById(transactionId).orElse(null);
     var updatedHold = (TransactionItemHold) updatedTransaction.getHold();
 
-    assertEquals(null, updatedHold.getPatronName());
-    assertEquals(null, updatedHold.getPatronId());
-    assertEquals(null, updatedTransaction.getHold().getDueDateTime());
+    assertNull(updatedHold.getPatronName());
+    assertNull(updatedHold.getPatronId());
+    assertNull(updatedTransaction.getHold().getDueDateTime());
     assertEquals(FINAL_CHECKIN, updatedTransaction.getState());
   }
 
@@ -560,4 +556,18 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
       .data(new EntityChangedData<>(null, checkIn))
       .build();
   }
+
+  private static void assertPatronAndItemInfoCleared(TransactionHold itemHold) {
+    assertNull(itemHold.getPatronId());
+    assertNull(itemHold.getPatronName());
+    assertNull(itemHold.getFolioPatronId());
+    assertNull(itemHold.getFolioPatronBarcode());
+    assertNull(itemHold.getFolioItemId());
+    assertNull(itemHold.getFolioHoldingId());
+    assertNull(itemHold.getFolioInstanceId());
+    assertNull(itemHold.getFolioRequestId());
+    assertNull(itemHold.getFolioLoanId());
+    assertNull(itemHold.getFolioItemBarcode());
+  }
+
 }

--- a/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
@@ -215,7 +215,6 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
     verify(eventProcessor).process(anyList(), any(Consumer.class));
     verify(innReachExternalService).postInnReachApi(any(), any(), any());
     var updatedTransaction = transactionRepository.fetchOneById(PRE_POPULATED_LOCAL_TRANSACTION_ID).orElseThrow();
-    assertEquals(PRE_POPULATED_LOCAL_LOAN_ID, updatedTransaction.getHold().getFolioLoanId());
     assertEquals(LOCAL_CHECKOUT, updatedTransaction.getState());
 
     assertPatronAndItemInfoCleared(updatedTransaction.getHold());


### PR DESCRIPTION
## Purpose
When "localcheckout" message is sent to the central server, identifying information for the item requested and the patron who made the request should be removed from the INN-Reach Patron Hold transaction record.

JIRA: [MODINREACH-249](https://issues.folio.org/browse/MODINREACH-249)

## Approach
* clear patron/item information from transaction upon processing Created Loan event for Local transaction
* adjust tests

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
