### PR TITLE
MODINREACH-261 - Ensure that INN-Reach transaction state is persisted before Kafka events are consumed

### DIFF
--- a/src/main/java/org/folio/innreach/domain/event/CancelRequestEvent.java
+++ b/src/main/java/org/folio/innreach/domain/event/CancelRequestEvent.java
@@ -1,0 +1,22 @@
+package org.folio.innreach.domain.event;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import org.folio.innreach.domain.entity.InnReachTransaction;
+
+
+@AllArgsConstructor
+@Data
+public class CancelRequestEvent {
+  private String transactionTrackingId;
+  private UUID requestId;
+  private UUID cancellationReasonId;
+  private String details;
+
+  public static CancelRequestEvent of(InnReachTransaction transaction, UUID reasonId, String details) {
+    return new CancelRequestEvent(transaction.getTrackingId(), transaction.getHold().getFolioRequestId(), reasonId, details);
+  }
+}

--- a/src/main/java/org/folio/innreach/domain/event/RecallRequestEvent.java
+++ b/src/main/java/org/folio/innreach/domain/event/RecallRequestEvent.java
@@ -1,0 +1,22 @@
+package org.folio.innreach.domain.event;
+
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import org.folio.innreach.domain.entity.InnReachRecallUser;
+import org.folio.innreach.domain.entity.TransactionHold;
+
+@AllArgsConstructor
+@Data
+public class RecallRequestEvent {
+  private UUID recallUserId;
+  private UUID itemId;
+  private UUID instanceId;
+  private UUID holdingId;
+
+  public static RecallRequestEvent of(TransactionHold hold, InnReachRecallUser recallUser) {
+    return new RecallRequestEvent(recallUser.getUserId(), hold.getFolioItemId(), hold.getFolioInstanceId(), hold.getFolioHoldingId());
+  }
+}

--- a/src/main/java/org/folio/innreach/domain/listener/ApplicationEventListener.java
+++ b/src/main/java/org/folio/innreach/domain/listener/ApplicationEventListener.java
@@ -1,0 +1,37 @@
+package org.folio.innreach.domain.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import org.folio.innreach.domain.event.CancelRequestEvent;
+import org.folio.innreach.domain.event.RecallRequestEvent;
+import org.folio.innreach.domain.service.RequestService;
+
+@Service
+@RequiredArgsConstructor
+public class ApplicationEventListener {
+
+  private final RequestService requestService;
+
+  @TransactionalEventListener
+  public void handleCancelRequestEvent(CancelRequestEvent event) {
+    var trackingId = event.getTransactionTrackingId();
+    var requestId = event.getRequestId();
+    var reasonId = event.getCancellationReasonId();
+    var details = event.getDetails();
+
+    requestService.cancelRequest(trackingId, requestId, reasonId, details);
+  }
+
+  @TransactionalEventListener
+  public void handleRecallRequestEvent(RecallRequestEvent event) {
+    var recallUserId = event.getRecallUserId();
+    var itemId = event.getItemId();
+    var instanceId = event.getInstanceId();
+    var holdingId = event.getHoldingId();
+
+    requestService.createRecallRequest(recallUserId, itemId, instanceId, holdingId);
+  }
+
+}

--- a/src/main/java/org/folio/innreach/domain/service/RequestService.java
+++ b/src/main/java/org/folio/innreach/domain/service/RequestService.java
@@ -23,13 +23,9 @@ public interface RequestService {
 
   void moveItemRequest(InnReachTransaction transaction, Holding holding, InventoryItemDTO item);
 
-  void cancelRequest(InnReachTransaction transaction, String reason);
-
-  void cancelRequest(String trackingId, UUID requestId, String reason);
-
   void cancelRequest(String trackingId, UUID requestId, UUID reasonId, String reason);
 
-  void createRecallRequest(InnReachTransaction transaction, UUID userId);
+  void createRecallRequest(UUID recallUserId, UUID itemId, UUID instanceId, UUID holdingId);
 
   RequestDTO findRequest(UUID requestId);
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -26,6 +26,7 @@ import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionSt
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionType.ITEM;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionType.LOCAL;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionType.PATRON;
+import static org.folio.innreach.domain.service.impl.RequestServiceImpl.INN_REACH_CANCELLATION_REASON_ID;
 import static org.folio.innreach.util.DateHelper.toEpochSec;
 import static org.folio.innreach.util.InnReachTransactionUtils.clearCentralPatronInfo;
 import static org.folio.innreach.util.InnReachTransactionUtils.clearPatronAndItemInfo;
@@ -45,6 +46,7 @@ import javax.persistence.EntityExistsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.BeanUtils;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
@@ -59,6 +61,8 @@ import org.folio.innreach.domain.entity.InnReachTransaction.TransactionState;
 import org.folio.innreach.domain.entity.InnReachTransaction.TransactionType;
 import org.folio.innreach.domain.entity.LocalAgency;
 import org.folio.innreach.domain.entity.TransactionHold;
+import org.folio.innreach.domain.event.CancelRequestEvent;
+import org.folio.innreach.domain.event.RecallRequestEvent;
 import org.folio.innreach.domain.exception.CirculationException;
 import org.folio.innreach.domain.exception.EntityNotFoundException;
 import org.folio.innreach.domain.service.CentralServerService;
@@ -125,6 +129,7 @@ public class CirculationServiceImpl implements CirculationService {
   private final LocalAgencyRepository localAgencyRepository;
   private final PatronInfoService patronInfoService;
   private final TransactionTemplate transactionTemplate;
+  private final ApplicationEventPublisher eventPublisher;
 
   @Override
   public InnReachResponseDTO createInnReachTransactionItemHold(String trackingId, String centralCode, TransactionHoldDTO dto) {
@@ -216,11 +221,11 @@ public class CirculationServiceImpl implements CirculationService {
 
     removeItemTransactionInfo(itemId)
       .ifPresent(this::removeHoldingsTransactionInfo);
+
     clearPatronAndItemInfo(transaction.getHold());
 
-    saveAndPersist(transaction);
-
-    requestService.cancelRequest(trackingId, requestId, cancelRequest.getReason());
+    eventPublisher.publishEvent(new CancelRequestEvent(trackingId, requestId,
+      INN_REACH_CANCELLATION_REASON_ID, cancelRequest.getReason()));
 
     log.info("Item request successfully cancelled");
 
@@ -246,20 +251,18 @@ public class CirculationServiceImpl implements CirculationService {
     log.info("Cancelling Item Hold transaction: {}", trackingId);
 
     var transaction = getTransactionOfType(trackingId, centralCode, ITEM);
+    var requestId = transaction.getHold().getFolioRequestId();
 
     if (transaction.getHold().getFolioLoanId() != null) {
       throw new IllegalArgumentException("Requested item is already checked out.");
     }
 
-    // the state should be updated before cancelRequest called as the transaction should be in a proper state when
-    // kafka event for a request update is consumed after the cancellation
     transaction.setState(BORROWING_SITE_CANCEL);
 
     clearCentralPatronInfo(transaction.getHold());
 
-    transaction = saveAndPersist(transaction);
-
-    requestService.cancelRequest(transaction, "Request cancelled at borrowing site");
+    eventPublisher.publishEvent(new CancelRequestEvent(trackingId, requestId,
+      INN_REACH_CANCELLATION_REASON_ID, "Request cancelled at borrowing site"));
 
     return success();
   }
@@ -334,27 +337,21 @@ public class CirculationServiceImpl implements CirculationService {
   public InnReachResponseDTO recall(String trackingId, String centralCode, RecallDTO recall) {
     var transaction = getTransactionOfType(trackingId, centralCode, PATRON);
     patronInfoService.populateTransactionPatronInfo(transaction.getHold(), centralCode);
+
     var requestId = transaction.getHold().getFolioRequestId();
     var request = requestService.findRequest(requestId);
     var requestStatus = request.getStatus();
 
-    if (requestStatus == OPEN_AWAITING_PICKUP || requestStatus == OPEN_IN_TRANSIT) {
-      try {
-        requestService.cancelRequest(transaction, "Item has been recalled.");
-      } catch (Exception e) {
-        throw new CirculationException("Unable to create a cancel request on the item: " + e.getMessage(), e);
-      }
-    } else {
-      try {
-        var recallUser = getRecallUserForCentralServer(centralCode);
-        requestService.createRecallRequest(transaction, recallUser.getUserId());
-      } catch (Exception e) {
-        throw new CirculationException("Unable to create a recall request on the item: " + e.getMessage(), e);
-      }
-    }
-
     transaction.getHold().setDueDateTime(recall.getDueDateTime());
     transaction.setState(RECALL);
+
+    if (requestStatus == OPEN_AWAITING_PICKUP || requestStatus == OPEN_IN_TRANSIT) {
+      eventPublisher.publishEvent(CancelRequestEvent.of(transaction,
+        INN_REACH_CANCELLATION_REASON_ID, "Item has been recalled."));
+    } else {
+      var recallUser = getRecallUserForCentralServer(centralCode);
+      eventPublisher.publishEvent(RecallRequestEvent.of(transaction.getHold(), recallUser));
+    }
 
     return success();
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -217,7 +217,6 @@ public class CirculationServiceImpl implements CirculationService {
     transaction.setState(CANCEL_REQUEST);
 
     var itemId = transaction.getHold().getFolioItemId();
-    var requestId = transaction.getHold().getFolioRequestId();
 
     removeItemTransactionInfo(itemId)
       .ifPresent(this::removeHoldingsTransactionInfo);

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -222,10 +222,10 @@ public class CirculationServiceImpl implements CirculationService {
     removeItemTransactionInfo(itemId)
       .ifPresent(this::removeHoldingsTransactionInfo);
 
-    clearPatronAndItemInfo(transaction.getHold());
-
-    eventPublisher.publishEvent(new CancelRequestEvent(trackingId, requestId,
+    eventPublisher.publishEvent(CancelRequestEvent.of(transaction,
       INN_REACH_CANCELLATION_REASON_ID, cancelRequest.getReason()));
+
+    clearPatronAndItemInfo(transaction.getHold());
 
     log.info("Item request successfully cancelled");
 
@@ -445,16 +445,6 @@ public class CirculationServiceImpl implements CirculationService {
     transaction.setType(InnReachTransaction.TransactionType.ITEM);
     transaction.setState(InnReachTransaction.TransactionState.ITEM_HOLD);
     return transaction;
-  }
-
-  /**
-   * Executes save operation in a new DB transaction without waiting for existing transaction to be completed
-   *
-   * @param transaction INN-Reach transaction to be saved
-   * @return the saved entity
-   */
-  private InnReachTransaction saveAndPersist(InnReachTransaction transaction) {
-    return transactionTemplate.execute(status -> transactionRepository.save(transaction));
   }
 
   private void initiateTransactionHold(String trackingId, String centralCode,

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -15,7 +15,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -30,7 +29,6 @@ import static org.folio.innreach.domain.dto.folio.inventory.InventoryItemStatus.
 import static org.folio.innreach.domain.dto.folio.inventory.InventoryItemStatus.IN_TRANSIT;
 import static org.folio.innreach.domain.dto.folio.inventory.InventoryItemStatus.MISSING;
 import static org.folio.innreach.domain.dto.folio.inventory.InventoryItemStatus.UNAVAILABLE;
-import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.BORROWING_SITE_CANCEL;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.CANCEL_REQUEST;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.FINAL_CHECKIN;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
@@ -1570,10 +1568,7 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
 
     var cancelRequestCaptor = ArgumentCaptor.forClass(RequestDTO.class);
 
-    var inOrder = inOrder(repository, circulationClient);
-
-    inOrder.verify(repository).save(argThat(t -> t.getState() == BORROWING_SITE_CANCEL));
-    inOrder.verify(circulationClient).updateRequest(eq(PRE_POPULATED_PATRON_HOLD_REQUEST_ID), cancelRequestCaptor.capture());
+    verify(circulationClient).updateRequest(eq(PRE_POPULATED_PATRON_HOLD_REQUEST_ID), cancelRequestCaptor.capture());
 
     var cancelRequest = cancelRequestCaptor.getValue();
     assertEquals(CLOSED_CANCELLED, cancelRequest.getStatus());

--- a/src/test/java/org/folio/innreach/controller/d2ir/CirculationApiTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/CirculationApiTest.java
@@ -245,7 +245,7 @@ class CirculationApiTest extends BaseApiControllerTest {
         .headers(getOkapiHeaders()))
       .andExpect(status().isOk());
 
-    verify(requestService).cancelRequest(anyString(), any(UUID.class), eq("Test reason"));
+    verify(requestService).cancelRequest(anyString(), any(UUID.class), any(UUID.class), eq("Test reason"));
     verify(circulationClient).updateRequest(any(), any());
   }
 


### PR DESCRIPTION
## Purpose
After a message from central server is received by mod-inn-reach, the changes to FOLIO records are performed and some of them trigger Kafka events (for request/loan/etc). The problem is that the Kafka event can be then received by mod-inn-reach before the method that handles the message from central server is completed (i.e. before the changes to INN-Reach transaction are persisted to DB) which lead to incorrect processing of an event in cases when it depends on a state of the transaction.

JIRA: [MODINREACH-261](https://issues.folio.org/browse/MODINREACH-261)

## Approach
- Add transactional event listener
- Push events to trigger request cancellation and recall
- Update tests

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
