### PR TITLE
MODINREACH-275 - INN-Reach Transaction Detail View Action Menu (Item hold) - Transfer hold to another item (for TRANSFER state)

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -295,7 +295,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
   public void transferItemHold(UUID transactionId, UUID itemId) {
     var transaction = fetchTransactionOfType(transactionId, ITEM);
 
-    verifyState(transaction, ITEM_HOLD);
+    verifyState(transaction, ITEM_HOLD, TRANSFER);
 
     var item = fetchItemById(itemId);
     var request = requestService.findRequest(transaction.getHold().getFolioRequestId());

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -1765,12 +1765,13 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     verify(circulationClient).moveRequest(eq(PRE_POPULATED_ITEM_HOLD_REQUEST_ID), any());
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(names = {"ITEM_HOLD", "TRANSFER"})
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql",
   })
-  void transferItemHoldItem_linkMovedRequest() {
+  void transferItemHoldItem_linkMovedRequest(InnReachTransaction.TransactionState state) {
     var item = createInventoryItemDTO();
     item.setStatus(AVAILABLE);
     var itemId = item.getId();
@@ -1778,6 +1779,8 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     var request = createRequestDTO();
     request.setStatus(OPEN_AWAITING_PICKUP);
     request.setItemId(itemId);
+
+    modifyTransactionState(PRE_POPULATED_ITEM_HOLD_TRANSACTION_ID, state);
 
     when(inventoryClient.findItem(any())).thenReturn(Optional.of(item));
     when(circulationClient.findRequest(any())).thenReturn(Optional.of(request));


### PR DESCRIPTION
[MODINREACH-275](https://issues.folio.org/browse/MODINREACH-275) - INN-Reach Transaction Detail View Action Menu (Item hold) - Transfer hold to another item (for TRANSFER state)

## Purpose
add the ability to support the TRANSFER state in the ["transfer-item"](https://s3.amazonaws.com/foliodocs/api/mod-inn-reach/s/circulation.html#operation/transferItemHold) request.

## Approach
TRANSFER state added to verification

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?