### PR TITLE
MODINREACH-283 - Update transaction when item barcode updated

### DIFF
--- a/src/main/java/org/folio/innreach/domain/listener/KafkaInventoryEventListener.java
+++ b/src/main/java/org/folio/innreach/domain/listener/KafkaInventoryEventListener.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import org.folio.innreach.domain.event.DomainEvent;
 import org.folio.innreach.domain.service.ContributionActionService;
+import org.folio.innreach.domain.service.InnReachTransactionActionService;
 import org.folio.innreach.domain.service.impl.BatchDomainEventProcessor;
 import org.folio.innreach.dto.Holding;
 import org.folio.innreach.dto.Instance;
@@ -27,6 +28,7 @@ public class KafkaInventoryEventListener {
 
   private final BatchDomainEventProcessor eventProcessor;
   private final ContributionActionService contributionActionService;
+  private final InnReachTransactionActionService transactionActionService;
 
   @KafkaListener(
     containerFactory = KAFKA_CONTAINER_FACTORY,
@@ -48,6 +50,7 @@ public class KafkaInventoryEventListener {
           break;
         case UPDATED:
           contributionActionService.handleItemUpdate(newEntity, oldEntity);
+          transactionActionService.handleItemUpdate(newEntity, oldEntity);
           break;
         case DELETED:
           contributionActionService.handleItemDelete(oldEntity);

--- a/src/main/java/org/folio/innreach/domain/service/InnReachTransactionActionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/InnReachTransactionActionService.java
@@ -6,6 +6,7 @@ import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
 import org.folio.innreach.dto.CancelTransactionHoldDTO;
 import org.folio.innreach.dto.CheckInDTO;
 import org.folio.innreach.dto.InnReachTransactionDTO;
+import org.folio.innreach.dto.Item;
 import org.folio.innreach.dto.PatronHoldCheckInResponseDTO;
 import org.folio.innreach.dto.StorageLoanDTO;
 import org.folio.innreach.dto.TransactionCheckOutResponseDTO;
@@ -29,6 +30,8 @@ public interface InnReachTransactionActionService {
   void handleRequestUpdate(RequestDTO requestDTO);
 
   void handleCheckInCreation(CheckInDTO checkIn);
+
+  void handleItemUpdate(Item updatedItem, Item oldItem);
 
   InnReachTransactionDTO cancelPatronHold(UUID transactionId, CancelTransactionHoldDTO cancelRequest);
 

--- a/src/test/java/org/folio/innreach/domain/listener/KafkaInventoryEventListenerApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/KafkaInventoryEventListenerApiTest.java
@@ -4,6 +4,8 @@ import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 
 import static org.folio.innreach.fixture.ContributionFixture.createHolding;
 import static org.folio.innreach.fixture.ContributionFixture.createInstance;
@@ -19,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
 
 import org.folio.innreach.domain.event.DomainEvent;
 import org.folio.innreach.domain.event.DomainEventType;
@@ -28,11 +32,22 @@ import org.folio.innreach.domain.service.ContributionActionService;
 import org.folio.innreach.dto.Holding;
 import org.folio.innreach.dto.Instance;
 import org.folio.innreach.dto.Item;
+import org.folio.innreach.repository.InnReachTransactionRepository;
 
+@Sql(
+  scripts = {"classpath:db/inn-reach-transaction/clear-inn-reach-transaction-tables.sql",
+    "classpath:db/central-server/clear-central-server-tables.sql",
+  },
+  executionPhase = AFTER_TEST_METHOD
+)
+@SqlMergeMode(MERGE)
 class KafkaInventoryEventListenerApiTest extends BaseKafkaApiTest {
   private static final UUID RECORD_ID = UUID.randomUUID();
   private static final String TEST_TENANT_ID = "testing";
   private static final Duration ASYNC_AWAIT_TIMEOUT = Duration.ofSeconds(15);
+
+  private static final UUID PRE_POPULATED_LOCAL_TRANSACTION_ID = UUID.fromString("79b0a1fb-55be-4e55-9d84-01303aaec1ce");
+  private static final UUID PRE_POPULATED_LOCAL_ITEM_ID = UUID.fromString("c633da85-8112-4453-af9c-c250e417179d");
 
   @SpyBean
   private KafkaInventoryEventListener listener;
@@ -40,9 +55,12 @@ class KafkaInventoryEventListenerApiTest extends BaseKafkaApiTest {
   @MockBean
   private ContributionActionService actionService;
 
+  @SpyBean
+  private InnReachTransactionRepository transactionRepository;
+
   @Test
   void shouldReceiveInventoryItemEvent() {
-    var event = createItemDomainEvent(DomainEventType.DELETED);
+    var event = createItemDomainEvent(DomainEventType.DELETED, UUID.randomUUID());
 
     kafkaTemplate.send(new ProducerRecord(INVENTORY_ITEM_TOPIC, RECORD_ID.toString(), event));
 
@@ -103,14 +121,31 @@ class KafkaInventoryEventListenerApiTest extends BaseKafkaApiTest {
     assertEquals(event, record.value());
   }
 
-  private DomainEvent<Item> createItemDomainEvent(DomainEventType eventType) {
-    var item = createItem();
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql",
+  })
+  void shouldHandleItemBarcodeUpdate() {
+    var event = createItemDomainEvent(DomainEventType.UPDATED, PRE_POPULATED_LOCAL_ITEM_ID);
+    var updatedItem = event.getData().getNewEntity();
+
+    listener.handleItemEvents(asSingleConsumerRecord(INVENTORY_ITEM_TOPIC, PRE_POPULATED_LOCAL_ITEM_ID, event));
+
+    var transaction = transactionRepository.fetchOneById(PRE_POPULATED_LOCAL_TRANSACTION_ID).orElseThrow();
+
+    assertEquals(updatedItem.getBarcode(), transaction.getHold().getFolioItemBarcode());
+  }
+
+  private DomainEvent<Item> createItemDomainEvent(DomainEventType eventType, UUID recordId) {
+    var oldItem = createItem().id(recordId);
+    var newItem = createItem().id(recordId);
 
     return DomainEvent.<Item>builder()
       .tenant(TEST_TENANT_ID)
       .timestamp(System.currentTimeMillis())
       .type(eventType)
-      .data(new EntityChangedData<>(item, item))
+      .data(new EntityChangedData<>(newItem, oldItem))
       .build();
   }
 


### PR DESCRIPTION
## Purpose
When attempting to perform a "Checkout to local patron" action via the Local Hold transaction detail action menu on an item that has had it's barcode changed after the transaction was created, the check-out fails. We should update transaction when item's barcode updated.

## Approach
- Add handler for item update to transaction action service
- Add tests

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
