### PR TITLE
MODINREACH-281-FIX - update method fix

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/CentralServerServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CentralServerServiceImpl.java
@@ -152,6 +152,7 @@ public class CentralServerServiceImpl implements CentralServerService {
     centralServer.setCentralServerCode(updatedCentralServer.getCentralServerCode());
     centralServer.setCentralServerAddress(updatedCentralServer.getCentralServerAddress());
     centralServer.setLoanTypeId(updatedCentralServer.getLoanTypeId());
+    centralServer.setCheckPickupLocation(updatedCentralServer.isCheckPickupLocation());
   }
 
   private void updateCentralServerCredentials(CentralServer centralServer, CentralServerCredentials updatedCentralServerCredentials) {

--- a/src/test/java/org/folio/innreach/controller/CentralServerControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/CentralServerControllerTest.java
@@ -132,11 +132,22 @@ class CentralServerControllerTest extends BaseControllerTest {
       "/central-server/update-central-server-request.json", CentralServerDTO.class);
     centralServerRequestDTO.setCheckPickupLocation(true);
 
-    var responseEntity = testRestTemplate.exchange(
+    var responseEntityPut = testRestTemplate.exchange(
       "/inn-reach/central-servers/{centralServerId}", HttpMethod.PUT, new HttpEntity<>(centralServerRequestDTO),
       CentralServerDTO.class, PRE_POPULATED_CENTRAL_SERVER_ID);
 
-    assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
+    assertTrue(responseEntityPut.getStatusCode().is2xxSuccessful());
+
+    var responseEntityGet = testRestTemplate.getForEntity(
+      "/inn-reach/central-servers/{centralServerId}", CentralServerDTO.class, PRE_POPULATED_CENTRAL_SERVER_ID);
+
+    assertTrue(responseEntityGet.getStatusCode().is2xxSuccessful());
+    assertTrue(responseEntityGet.hasBody());
+
+    var centralServer = responseEntityGet.getBody();
+
+    assertNotNull(centralServer);
+    assertTrue(centralServer.getCheckPickupLocation());
   }
 
   @Test


### PR DESCRIPTION
MODINREACH-281-FIX - update method fix

## Purpose
missed checkPickupLocation field in update central server method

## Approach
checkPickupLocaton field added to update central server method

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [x] There are no breaking changes in this PR.