### PR TITLE
MODINREACH-296 - Add centralServerId to the transaction tokens so that it could be mapped with the corresponding slip tempate

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/PagingSlipServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PagingSlipServiceImpl.java
@@ -264,6 +264,7 @@ public class PagingSlipServiceImpl implements PagingSlipService {
       .patronTypeCode(centralPatronType)
       .patronTypeDescription(patronTypeDescription)
       .centralServerCode(centralServerCode)
+      .centralServerId(centralServer.getId())
       .localServerCode(centralServer.getLocalServerCode())
       .itemAgencyCode(itemAgencyCode)
       .itemAgencyDescription(itemAgencyDescription)

--- a/src/main/resources/swagger.api/schemas/pagingSlipsDTO.json
+++ b/src/main/resources/swagger.api/schemas/pagingSlipsDTO.json
@@ -40,6 +40,11 @@
                 "description": "Unique code that identifies the central server",
                 "type": "string"
               },
+              "centralServerId": {
+                "description": "UUID of the central server configuration",
+                "type": "string",
+                "format": "UUID"
+              },
               "localServerCode": {
                 "description": "Unique code that identifies the local server",
                 "type": "string"

--- a/src/test/java/org/folio/innreach/controller/PagingSlipControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/PagingSlipControllerTest.java
@@ -58,6 +58,7 @@ class PagingSlipControllerTest extends BaseControllerTest {
   private static final String PRE_POPULATED_ITEM_AGENCY_CODE = "asd78";
   private static final Integer PRE_POPULATED_CENTRAL_PATRON_TYPE = 1;
   private static final String PRE_POPULATED_CENTRAL_SERVER_CODE = "d2ir";
+  private static final UUID PRE_POPULATED_CENTRAL_SERVER_ID = UUID.fromString("edab6baf-c696-42b1-89bb-1bbb8759b0d2");
   private static final String PRE_POPULATED_LOCAL_SERVER_CODE = "test1";
   private static final String PRE_POPULATED_PICKUP_LOCATION_CODE = "pickupLocCode2";
   private static final String PRE_POPULATED_PICKUP_LOCATION_NAME = "displayName2";
@@ -146,6 +147,7 @@ class PagingSlipControllerTest extends BaseControllerTest {
     assertEquals(PRE_POPULATED_CENTRAL_PATRON_TYPE, transactionSlip.getPatronTypeCode());
     assertEquals(CENTRAL_PATRON_DESCRIPTION, transactionSlip.getPatronTypeDescription());
     assertEquals(PRE_POPULATED_CENTRAL_SERVER_CODE, transactionSlip.getCentralServerCode());
+    assertEquals(PRE_POPULATED_CENTRAL_SERVER_ID, transactionSlip.getCentralServerId());
     assertEquals(PRE_POPULATED_LOCAL_SERVER_CODE, transactionSlip.getLocalServerCode());
     assertEquals(PRE_POPULATED_ITEM_AGENCY_CODE, transactionSlip.getItemAgencyCode());
     assertEquals(ITEM_AGENCY_DESCRIPTION, transactionSlip.getItemAgencyDescription());


### PR DESCRIPTION
## Purpose
Add centralServerId to the transaction tokens so that it could be mapped with the corresponding slip tempate
https://issues.folio.org/browse/MODINREACH-296

## Approach
- Update pagingSlipDTO schema
- Set central server id
- Update test

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
