### PR TITLE
MODINREACH-304: Support inventory 12.0 in ModuleDescriptor "requires"

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## v2.1.0 IN-PROGRESS
 
 * Supports users interface version 15.3 16.0 (MODINREACH-303)
+* Supports inventory interface version 11.1 12.0 ([MODINREACH-304](https://issues.folio.org/browse/MODINREACH-304))
 
 ## v2.0.0 2022-08-17
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "inventory",
-      "version": "11.1"
+      "version": "11.1 12.0"
     },
     {
       "id": "service-points-users",


### PR DESCRIPTION
Add version 12.0 to the list of supported inventory interface versions in ModuleDescriptor "requires" section.

DELETE /inventory/instances and DELETE /inventory/items have been deleting all records.

MODINV-731 changed them to delete records by CQL, this requires a major interface version bump.

mod-inn-reach doesn't need any code change for this because it doesn't use these two DELETE APIs.