### PR TITLE
[MODINREACH-307]: Searching for transactions by Patron Name does not return any results

### DIFF
--- a/src/main/java/org/folio/innreach/specification/InnReachTransactionSpecification.java
+++ b/src/main/java/org/folio/innreach/specification/InnReachTransactionSpecification.java
@@ -86,10 +86,11 @@ public class InnReachTransactionSpecification {
       var trackingIdMatch = cb.equal(transaction.get("trackingId"), keyword);
       var patronBarcodeMatch = cb.equal(hold.get("folioPatronBarcode"), keyword);
       var itemBarcodeMatch = cb.equal(hold.get("folioItemBarcode"), keyword);
+      var patronNameLike = cb.like(cb.lower(hold.get("patronName")), "%" + lowerCaseKeyword + "%");
       var itemAuthorLike = cb.like(cb.lower(hold.get("author")), "%" + lowerCaseKeyword + "%");
       var itemTitleLike = cb.like(cb.lower(hold.get("title")), "%" + lowerCaseKeyword + "%");
 
-      return cb.or(itemIdMatch, patronIdMatch, trackingIdMatch, patronBarcodeMatch, itemBarcodeMatch, itemAuthorLike, itemTitleLike);
+      return cb.or(itemIdMatch, patronIdMatch, trackingIdMatch, patronBarcodeMatch, itemBarcodeMatch, patronNameLike, itemAuthorLike, itemTitleLike);
     };
   }
 

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -591,6 +591,25 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
   @Test
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void return200HttpCode_and_sortedTransactionList_when_getTransactionsWithPatronName() {
+    var responseEntity = testRestTemplate.getForEntity(
+      "/inn-reach/transactions?query=patronName1", InnReachTransactionsDTO.class
+    );
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+    assertEquals(1, responseEntity.getBody().getTotalRecords());
+
+    var transactions = responseEntity.getBody().getTransactions();
+    assertEquals(1, transactions.size());
+    assertEquals("patronName1", transactions.get(0).getHold().getPatronName());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql",
     "classpath:db/inn-reach-transaction/pre-populate-another-inn-reach-transaction.sql"
   })


### PR DESCRIPTION
[MODINREACH-307](https://issues.folio.org/browse/MODINREACH-307)

## Purpose
Searching for transactions by patron name does not return any results

## Approach
Keyword search by patron name added to search specification.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
