### PR TITLE
[MODINREACH-333] - "Request too long" report does not include PATRON_HOLD transactions without updatedDate

### DIFF
--- a/src/main/java/org/folio/innreach/domain/entity/InnReachTransactionFilterParameters.java
+++ b/src/main/java/org/folio/innreach/domain/entity/InnReachTransactionFilterParameters.java
@@ -19,6 +19,7 @@ public class InnReachTransactionFilterParameters {
   private List<Integer> centralItemTypes;
   private List<String> patronNames;
   private String query;
+  private boolean requestedTooLong;
   private List<OffsetDateTime> createdDates;
   private DateOperation createdDateOperation;
   private List<OffsetDateTime> updatedDates;

--- a/src/main/java/org/folio/innreach/specification/InnReachTransactionSpecification.java
+++ b/src/main/java/org/folio/innreach/specification/InnReachTransactionSpecification.java
@@ -2,6 +2,8 @@ package org.folio.innreach.specification;
 
 import static org.apache.commons.collections4.CollectionUtils.isEmpty;
 
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.PATRON_HOLD;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.TRANSFER;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionType.PATRON;
 import static org.folio.innreach.domain.entity.InnReachTransactionFilterParameters.SortOrder.DESC;
 import static org.folio.innreach.util.ListUtils.mapItems;
@@ -30,6 +32,8 @@ public class InnReachTransactionSpecification {
   private static final String CREATED_DATE_FIELD = "createdDate";
   private static final String UPDATED_DATE_FIELD = "updatedDate";
 
+  private static final String STATE = "state";
+
   public Specification<InnReachTransaction> filterByParameters(InnReachTransactionFilterParameters parameters) {
     return fetchHoldAndPickupLocation()
       .and(fieldsLookup(parameters))
@@ -39,6 +43,7 @@ public class InnReachTransactionSpecification {
 
   static Specification<InnReachTransaction> fieldsLookup(InnReachTransactionFilterParameters parameters) {
     return (transaction, cq, cb) -> {
+      var isRequestTooLongReport = parameters.isRequestedTooLong();
       var hold = transaction.join("hold");
       var patronHold = cb.treat(hold, TransactionPatronHold.class);
 
@@ -67,9 +72,23 @@ public class InnReachTransactionSpecification {
       var dueDateIs = new ConditionFactory<Integer>(cb).create(parameters.getDueDateOperation())
           .applyArguments(hold.get("dueDateTime"), dueDatesAsEpochSecs);
 
-      return cb.and(typeIs, stateIs, centralCodeIn, patronAgencyIn, itemAgencyIn, patronTypeIn, centralItemTypeIn,
+      if(!isRequestTooLongReport) {
+        return cb.and(typeIs, stateIs, centralCodeIn, patronAgencyIn, itemAgencyIn, patronTypeIn, centralItemTypeIn,
           itemBarcodeIn, patronNameIn, createdDateIs, updatedDateIs, holdCreatedDateIs, holdUpdatedDateIs, dueDateIs);
+      } else {
+        var patronStateWithOrDateCondition = createCriteriaForRequestTooLongReport(cb,transaction,createdDateIs,updatedDateIs);
+        return cb.and(typeIs, stateIs, centralCodeIn, patronAgencyIn, itemAgencyIn, patronTypeIn, centralItemTypeIn,
+          itemBarcodeIn, patronNameIn, patronStateWithOrDateCondition, holdCreatedDateIs, holdUpdatedDateIs, dueDateIs);
+      }
     };
+  }
+
+  private static Predicate createCriteriaForRequestTooLongReport(CriteriaBuilder cb, Root<InnReachTransaction> transaction, Predicate createdDateIs, Predicate updatedDateIs) {
+      var holdState = cb.equal(transaction.get(STATE), PATRON_HOLD);
+      var holdStateAndCreateDate = cb.and(holdState,createdDateIs);
+      var transferState = cb.equal(transaction.get(STATE), TRANSFER);
+      var transferStateAndUpdatedDate = cb.and(transferState, updatedDateIs);
+      return cb.or(holdStateAndCreateDate, transferStateAndUpdatedDate);
   }
 
   static Specification<InnReachTransaction> keywordLookup(String keyword) {
@@ -113,7 +132,7 @@ public class InnReachTransactionSpecification {
   static Predicate isOfState(CriteriaBuilder cb, Root<InnReachTransaction> transaction,
       InnReachTransactionFilterParameters parameters) {
     var states = parameters.getStates();
-    return isEmpty(states) ? cb.conjunction() : transaction.get("state").in(states);
+    return isEmpty(states) ? cb.conjunction() : transaction.get(STATE).in(states);
   }
 
   static Predicate centralCodeIn(CriteriaBuilder cb, Root<InnReachTransaction> transaction,

--- a/src/main/resources/swagger.api/schemas/innReachTransactionFilterParametersDTO.json
+++ b/src/main/resources/swagger.api/schemas/innReachTransactionFilterParametersDTO.json
@@ -62,6 +62,10 @@
       "type": "string",
       "description": "Provides ability to perform a keyword-style lookup based on the information associated with the transaction"
     },
+    "requestedTooLong": {
+      "type": "boolean",
+      "description": "An indication that the filter is applied for the Request too long report."
+    },
     "createdDate": {
       "description": "Create date to which related comparison operation is applied. In case of 'between' operation there can be two values provided",
       "type": "array",

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -336,6 +336,29 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     assertEquals(PATRON_HOLD, transaction.getState());
   }
 
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void return200HttpCode_and_sortedTransactions_when_getRequestTooLongReport() {
+    var responseEntity = testRestTemplate.getForEntity(
+      "/inn-reach/transactions?createdDate=2022-11-16T18%3A30%3A00.000Z&createdDateOp=less&limit=1000&" +
+        "offset=0&requestedTooLong=true&sortBy=transactionTime&sortOrder=asc&state=PATRON_HOLD&" +
+        "state=TRANSFER&type=PATRON&updatedDate=2022-11-16T18%3A30%3A00.000Z&updatedDateOp=less"
+      , InnReachTransactionsDTO.class
+    );
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+    assertEquals(1, responseEntity.getBody().getTotalRecords());
+
+    var transactionIds = responseEntity.getBody().getTransactions().stream()
+      .map(InnReachTransactionDTO::getId).collect(Collectors.toList());
+    assertTrue(transactionIds.contains(PRE_POPULATED_PATRON_HOLD_TRANSACTION_ID));
+  }
+
   @Test
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -344,9 +344,9 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
   })
   void return200HttpCode_and_sortedTransactions_when_getRequestTooLongReport() {
     var responseEntity = testRestTemplate.getForEntity(
-      "/inn-reach/transactions?createdDate=2022-11-16T18%3A30%3A00.000Z&createdDateOp=less&limit=1000&" +
+      "/inn-reach/transactions?createdDate=3022-11-16T18%3A30%3A00.000Z&createdDateOp=less&limit=1000&" +
         "offset=0&requestedTooLong=true&sortBy=transactionTime&sortOrder=asc&state=PATRON_HOLD&" +
-        "state=TRANSFER&type=PATRON&updatedDate=2022-11-16T18%3A30%3A00.000Z&updatedDateOp=less"
+        "state=TRANSFER&type=PATRON&updatedDate=3022-11-16T18%3A30%3A00.000Z&updatedDateOp=less"
       , InnReachTransactionsDTO.class
     );
 


### PR DESCRIPTION
[MODINNREACH-333] ( https://issues.folio.org/browse/MODINREACH-333 )

## Purpose
When generating reports in UI-INN-Reach, transactions that have not been modified since their creation (eg. Patron Holds in status "PATRON_HOLD") are excluded from the report no matter the conditions. They should be included. It appears that the query used to generate this report is only checking for an updatedDate less than the indicated period.

## Approach
Send a flag which  signifies it is for "Request too long report" and to consider the minimum day requested value for transaction status as Patron_Hold then it should be sent as part of createdDate parameter. As per the flag the query will be reconstructed. For e.g. the modified part of the filter would be -

limit=1000&offset=0&sortBy=transactionTime&sortOrder=asc&state=PATRON_HOLD&state=TRANSFER&type=PATRON&updatedDate=2022-11-14T18%3A30%3A00.000Z&updatedDateOp=less`&createdDate=2022-11-14T18%3A30%3A00.000Z&createdDateOp=less&requestedTooLong=true`

Query will be constructed as -- 
 and (
            innreachtr0_.state=? _(PATRON_HOLD)_ 
            and innreachtr0_.created_date<? 
            or innreachtr0_.state=? _(TRANSFER)_
            and innreachtr0_.updated_date<?
        ) 

## Output 
![image](https://user-images.githubusercontent.com/34331959/202120554-e435702d-8ece-45a1-9b38-e9c8d3292e8f.png)
![image](https://user-images.githubusercontent.com/34331959/202120651-6df8d4d4-bb8b-4309-ae63-3401751a1a2b.png)
