### PR TITLE
Modinreach 331

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
@@ -228,10 +228,9 @@ public class PatronInfoServiceImpl implements PatronInfoService {
       return false;
     } else if (patronNameTokens.length == 2) {
       // "First Last" or "Middle Last" format or "Last First" or "Last Middle"
-      return (equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
+      return ((equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
         patronNameTokens[1].equals(personal.getLastName()))
-        || (equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
-            patronNameTokens[0].equals(personal.getLastName()));
+        || checkLastNameFirstName(personal, patronNameTokens));
     }
 
     // "First Middle Last" format "Last First Middle"
@@ -241,6 +240,12 @@ public class PatronInfoServiceImpl implements PatronInfoService {
       || (equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName()) &&
       patronNameTokens[2].equals(personal.getMiddleName()) &&
       patronNameTokens[0].equals(personal.getLastName()));
+  }
+
+  private static boolean checkLastNameFirstName(User.Personal personal, String[] patronNameTokens) {
+    boolean checkFirstName = equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName());
+    boolean checkLastName = patronNameTokens[0].equals(personal.getLastName());
+    return (checkFirstName && checkLastName);
   }
 
   private static String getPatronName(User user) {

--- a/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
@@ -228,23 +228,27 @@ public class PatronInfoServiceImpl implements PatronInfoService {
       return false;
     } else if (patronNameTokens.length == 2) {
       // "First Last" or "Middle Last" format or "Last First" or "Last Middle"
-      return ((equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
-        patronNameTokens[1].equals(personal.getLastName()))
-        || checkLastNameFirstName(personal, patronNameTokens));
+      return checkFirstNameLastNameWithPosition(personal, patronNameTokens,0,1)
+        || checkFirstNameLastNameWithPosition(personal, patronNameTokens,1,0);
     }
 
     // "First Middle Last" format "Last First Middle"
-    return (equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName()) &&
-      patronNameTokens[1].equals(personal.getMiddleName()) &&
-      patronNameTokens[2].equals(personal.getLastName()))
-      || (equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName()) &&
-      patronNameTokens[2].equals(personal.getMiddleName()) &&
-      patronNameTokens[0].equals(personal.getLastName()));
+    return (checkFirstNameMiddleNameLastNameWithPosition(personal, patronNameTokens,0,1,2)
+      || checkFirstNameMiddleNameLastNameWithPosition(personal, patronNameTokens,1,2,0));
   }
 
-  private static boolean checkLastNameFirstName(User.Personal personal, String[] patronNameTokens) {
-    boolean checkFirstName = equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName());
-    boolean checkLastName = patronNameTokens[0].equals(personal.getLastName());
+  private static boolean checkFirstNameMiddleNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,
+                                                                      int firstNamePosition,int middleNamePosition,int lastNamePosition) {
+
+    boolean checkFirstName = equalsAny(patronNameTokens[firstNamePosition], personal.getFirstName(), personal.getPreferredFirstName());
+    boolean checkMiddleName = patronNameTokens[middleNamePosition].equals(personal.getMiddleName());
+    boolean checkLastName = patronNameTokens[lastNamePosition].equals(personal.getLastName());
+    return checkFirstName && checkMiddleName && checkLastName;
+  }
+
+  private static boolean checkFirstNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,int firstNamePos,int lastNamePos) {
+    boolean checkFirstName = equalsAny(patronNameTokens[firstNamePos], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName());
+    boolean checkLastName = patronNameTokens[lastNamePos].equals(personal.getLastName());
     return (checkFirstName && checkLastName);
   }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
@@ -227,15 +227,20 @@ public class PatronInfoServiceImpl implements PatronInfoService {
     if (patronNameTokens.length < 2) {
       return false;
     } else if (patronNameTokens.length == 2) {
-      // "First Last" or "Middle Last" format
-      return equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
-        patronNameTokens[1].equals(personal.getLastName());
+      // "First Last" or "Middle Last" format or "Last First" or "Last Middle"
+      return (equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
+        patronNameTokens[1].equals(personal.getLastName()))
+        || (equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName()) &&
+            patronNameTokens[0].equals(personal.getLastName()));
     }
 
-    // "First Middle Last" format
-    return equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName()) &&
+    // "First Middle Last" format "Last First Middle"
+    return (equalsAny(patronNameTokens[0], personal.getFirstName(), personal.getPreferredFirstName()) &&
       patronNameTokens[1].equals(personal.getMiddleName()) &&
-      patronNameTokens[2].equals(personal.getLastName());
+      patronNameTokens[2].equals(personal.getLastName()))
+      || (equalsAny(patronNameTokens[1], personal.getFirstName(), personal.getPreferredFirstName()) &&
+      patronNameTokens[2].equals(personal.getMiddleName()) &&
+      patronNameTokens[0].equals(personal.getLastName()));
   }
 
   private static String getPatronName(User user) {

--- a/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
@@ -2,6 +2,7 @@ package org.folio.innreach.controller.d2ir;
 
 import static org.folio.innreach.fixture.PatronFixture.createUserWithoutExpirationDate;
 import static org.folio.innreach.fixture.PatronFixture.createUser;
+import static org.folio.innreach.fixture.PatronFixture.createUserWithMiddleName;
 import static org.folio.innreach.fixture.PatronFixture.createCustomFieldMapping;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -15,6 +16,9 @@ import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TES
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
 
 import static org.folio.innreach.fixture.PatronInfoRequestFixture.createPatronInfoRequest;
+import static org.folio.innreach.fixture.PatronInfoRequestFixture.createPatronInfoRequestWithLastNameFirstName;
+import static org.folio.innreach.fixture.PatronInfoRequestFixture.createPatronInfoRequestWithFirstNameMiddleNameLastName;
+import static org.folio.innreach.fixture.PatronInfoRequestFixture.createPatronInfoRequestWithLastNameFirstNameMiddleName;
 import static org.folio.innreach.fixture.TestUtil.circHeaders;
 
 import java.util.List;
@@ -115,6 +119,96 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
 
     var response = responseEntity.getBody();
     assertNotNull(response.getPatronInfo().getPatronExpireDate());
+    assertTrue(response.getRequestAllowed());
+    assertNotNull(response.getPatronInfo());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
+    "classpath:db/user-custom-field-mapping/pre-populate-user-custom-field-mapping.sql"
+  })
+  void return200HttpCode_and_patronInfoResponseWithPatronInfo_hasLastNameFirstNameOrder_when_patronFoundAndRequestAllowed() {
+    var user = createUser();
+    user.setPatronGroupId(UUID.fromString("54e17c4c-e315-4d20-8879-efc694dea1ce"));
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(1, List.of(user)));
+    when(automatedBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(manualBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(patronClient.getAccountDetails(any())).thenReturn(new PatronDTO());
+    when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
+
+    var patronInfoRequest = createPatronInfoRequestWithLastNameFirstName();
+    System.out.println("patronReq->"+ patronInfoRequest);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+
+    var response = responseEntity.getBody();
+    System.out.println("response->"+response.toString());
+    assertTrue(response.getRequestAllowed());
+    assertNotNull(response.getPatronInfo());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
+    "classpath:db/user-custom-field-mapping/pre-populate-user-custom-field-mapping.sql"
+  })
+  void return200HttpCode_and_patronInfoResponseWithPatronInfo_hasFirstNameMiddleNameLastNameOrder_when_patronFoundAndRequestAllowed() {
+    var user = createUserWithMiddleName();
+    user.setPatronGroupId(UUID.fromString("54e17c4c-e315-4d20-8879-efc694dea1ce"));
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(1, List.of(user)));
+    when(automatedBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(manualBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(patronClient.getAccountDetails(any())).thenReturn(new PatronDTO());
+    when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
+
+    var patronInfoRequest = createPatronInfoRequestWithFirstNameMiddleNameLastName();
+    System.out.println("patronReq->"+ patronInfoRequest);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+
+    var response = responseEntity.getBody();
+    System.out.println("response->"+response.toString());
+    assertTrue(response.getRequestAllowed());
+    assertNotNull(response.getPatronInfo());
+  }
+
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
+    "classpath:db/user-custom-field-mapping/pre-populate-user-custom-field-mapping.sql"
+  })
+  void return200HttpCode_and_patronInfoResponseWithPatronInfo_hasLastNameFirstNameMiddleNameOrder_when_patronFoundAndRequestAllowed() {
+    var user = createUserWithMiddleName();
+    user.setPatronGroupId(UUID.fromString("54e17c4c-e315-4d20-8879-efc694dea1ce"));
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(1, List.of(user)));
+    when(automatedBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(manualBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(patronClient.getAccountDetails(any())).thenReturn(new PatronDTO());
+    when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
+
+    var patronInfoRequest = createPatronInfoRequestWithLastNameFirstNameMiddleName();
+    System.out.println("patronReq->"+ patronInfoRequest);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+
+    var response = responseEntity.getBody();
+    System.out.println("response->"+response.toString());
     assertTrue(response.getRequestAllowed());
     assertNotNull(response.getPatronInfo());
   }

--- a/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -51,6 +53,7 @@ import org.folio.innreach.dto.PatronInfoResponseDTO;
   executionPhase = AFTER_TEST_METHOD)
 @SqlMergeMode(MERGE)
 class PatronInfoControllerTest extends BaseApiControllerTest {
+  public static final String UNABLE_TO_VERIFY_PATRON = "Unable to verify patron";
   @Autowired
   private TestRestTemplate testRestTemplate;
   @MockBean
@@ -211,6 +214,36 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     System.out.println("response->"+response.toString());
     assertTrue(response.getRequestAllowed());
     assertNotNull(response.getPatronInfo());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"John Paul Test","John Test Doe","John Test"})
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
+    "classpath:db/user-custom-field-mapping/pre-populate-user-custom-field-mapping.sql"
+  })
+  void return200HttpCode_and_patronInfoResponseWithPatronInfo_hasWrongOrder_when_patronNotFound(String updatedName) {
+    var user = createUserWithMiddleName();
+    user.setPatronGroupId(UUID.fromString("54e17c4c-e315-4d20-8879-efc694dea1ce"));
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(1, List.of(user)));
+    when(automatedBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(manualBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(patronClient.getAccountDetails(any())).thenReturn(new PatronDTO());
+    when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
+
+    var patronInfoRequest = createPatronInfoRequestWithLastNameFirstNameMiddleName();
+    patronInfoRequest.setPatronName(updatedName);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+
+    var response = responseEntity.getBody();
+    assertFalse(response.getRequestAllowed());
+    assertEquals(UNABLE_TO_VERIFY_PATRON,response.getReason());
   }
 
   @Test

--- a/src/test/java/org/folio/innreach/fixture/PatronFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/PatronFixture.java
@@ -29,6 +29,7 @@ public class PatronFixture {
   private static final long expiryDateTs = System.currentTimeMillis();
   public static final String PATRON_BLOCK_DESC = "test block desc";
   public static final String PATRON_BLOCK = "test block";
+  private static final String PATRON_MIDDLE_NAME = "Paul";
 
   public static AutomatedPatronBlock createAutomatedPatronBlock() {
     return AutomatedPatronBlock.builder().blockRequests(true).message(PATRON_BLOCK).build();
@@ -53,6 +54,16 @@ public class PatronFixture {
     user.setId(USER_ID);
     user.setActive(true);
     user.setPersonal(User.Personal.of(PATRON_FIRST_NAME, null, PATRON_LAST_NAME, null));
+    user.setCustomFields(Map.of(CUSTOM_FIELD_REF_ID, CUSTOM_FIELD_OPTION));
+    return user;
+  }
+
+  public static User createUserWithMiddleName() {
+    var user = new User();
+    user.setId(USER_ID);
+    user.setActive(true);
+    user.setExpirationDate(OffsetDateTime.ofInstant(Instant.ofEpochMilli(expiryDateTs), ZoneOffset.UTC));
+    user.setPersonal(User.Personal.of(PATRON_FIRST_NAME, PATRON_MIDDLE_NAME, PATRON_LAST_NAME, null));
     user.setCustomFields(Map.of(CUSTOM_FIELD_REF_ID, CUSTOM_FIELD_OPTION));
     return user;
   }

--- a/src/test/java/org/folio/innreach/fixture/PatronInfoRequestFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/PatronInfoRequestFixture.java
@@ -12,4 +12,29 @@ public class PatronInfoRequestFixture {
     patronInfoRequest.setPatronAgencyCode("test1");
     return patronInfoRequest;
   }
+
+  public static PatronInfoRequestDTO createPatronInfoRequestWithLastNameFirstName() {
+    var patronInfoRequest = new PatronInfoRequestDTO();
+    patronInfoRequest.setPatronName("Doe John");
+    patronInfoRequest.setVisiblePatronId("111111");
+    patronInfoRequest.setPatronAgencyCode("test1");
+    return patronInfoRequest;
+  }
+
+  public static PatronInfoRequestDTO createPatronInfoRequestWithFirstNameMiddleNameLastName() {
+    var patronInfoRequest = new PatronInfoRequestDTO();
+    patronInfoRequest.setPatronName("John Paul Doe");
+    patronInfoRequest.setVisiblePatronId("111111");
+    patronInfoRequest.setPatronAgencyCode("test1");
+    return patronInfoRequest;
+  }
+
+  public static PatronInfoRequestDTO createPatronInfoRequestWithLastNameFirstNameMiddleName() {
+    var patronInfoRequest = new PatronInfoRequestDTO();
+    patronInfoRequest.setPatronName("Doe John Paul");
+    patronInfoRequest.setVisiblePatronId("111111");
+    patronInfoRequest.setPatronAgencyCode("test1");
+    return patronInfoRequest;
+  }
+
 }


### PR DESCRIPTION
MODINREACH-331 (https://issues.folio.org/browse/MODINREACH-331)

## Purpose
Patron Verification API should accept the same name format it returns on a successful verification 


## Approach
1. Logic updated to handle Last Name - First Name & Last Name - First Name - Middle Name format, along with existing formats 
2. Test case added

## Output (attached)
[MODINNREACH-331.docx](https://github.com/folio-org/mod-inn-reach/files/10040948/MODINNREACH-331.docx)
