### PR TITLE
[MODINREACH-315] 1. updated PatronInfoServiceImpl to handle case sens…

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
@@ -4,7 +4,7 @@ import static java.lang.Boolean.TRUE;
 import static java.util.Optional.ofNullable;
 import static org.apache.commons.collections4.ListUtils.emptyIfNull;
 import static org.apache.commons.lang3.StringUtils.defaultIfEmpty;
-import static org.apache.commons.lang3.StringUtils.equalsAny;
+import static org.apache.commons.lang3.StringUtils.equalsAnyIgnoreCase;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 import static org.folio.innreach.domain.entity.VisiblePatronFieldConfiguration.VisiblePatronField.USER_CUSTOM_FIELDS;
@@ -240,15 +240,15 @@ public class PatronInfoServiceImpl implements PatronInfoService {
   private static boolean checkFirstNameMiddleNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,
                                                                       int firstNamePosition,int middleNamePosition,int lastNamePosition) {
 
-    boolean checkFirstName = equalsAny(patronNameTokens[firstNamePosition], personal.getFirstName(), personal.getPreferredFirstName());
-    boolean checkMiddleName = patronNameTokens[middleNamePosition].equals(personal.getMiddleName());
-    boolean checkLastName = patronNameTokens[lastNamePosition].equals(personal.getLastName());
+    boolean checkFirstName = equalsAnyIgnoreCase(patronNameTokens[firstNamePosition], personal.getFirstName(), personal.getPreferredFirstName());
+    boolean checkMiddleName = patronNameTokens[middleNamePosition].equalsIgnoreCase(personal.getMiddleName());
+    boolean checkLastName = patronNameTokens[lastNamePosition].equalsIgnoreCase(personal.getLastName());
     return checkFirstName && checkMiddleName && checkLastName;
   }
 
   private static boolean checkFirstNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,int firstNamePos,int lastNamePos) {
-    boolean checkFirstName = equalsAny(patronNameTokens[firstNamePos], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName());
-    boolean checkLastName = patronNameTokens[lastNamePos].equals(personal.getLastName());
+    boolean checkFirstName = equalsAnyIgnoreCase(patronNameTokens[firstNamePos], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName());
+    boolean checkLastName = patronNameTokens[lastNamePos].equalsIgnoreCase(personal.getLastName());
     return (checkFirstName && checkLastName);
   }
 

--- a/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
@@ -142,7 +142,6 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
 
     var patronInfoRequest = createPatronInfoRequestWithLastNameFirstName();
-    System.out.println("patronReq->"+ patronInfoRequest);
 
     var responseEntity = testRestTemplate.postForEntity(
       "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
@@ -151,7 +150,6 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     assertNotNull(responseEntity.getBody());
 
     var response = responseEntity.getBody();
-    System.out.println("response->"+response.toString());
     assertTrue(response.getRequestAllowed());
     assertNotNull(response.getPatronInfo());
   }
@@ -172,7 +170,6 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
 
     var patronInfoRequest = createPatronInfoRequestWithFirstNameMiddleNameLastName();
-    System.out.println("patronReq->"+ patronInfoRequest);
 
     var responseEntity = testRestTemplate.postForEntity(
       "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
@@ -181,7 +178,6 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     assertNotNull(responseEntity.getBody());
 
     var response = responseEntity.getBody();
-    System.out.println("response->"+response.toString());
     assertTrue(response.getRequestAllowed());
     assertNotNull(response.getPatronInfo());
   }
@@ -202,7 +198,6 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
 
     var patronInfoRequest = createPatronInfoRequestWithLastNameFirstNameMiddleName();
-    System.out.println("patronReq->"+ patronInfoRequest);
 
     var responseEntity = testRestTemplate.postForEntity(
       "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
@@ -211,7 +206,6 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     assertNotNull(responseEntity.getBody());
 
     var response = responseEntity.getBody();
-    System.out.println("response->"+response.toString());
     assertTrue(response.getRequestAllowed());
     assertNotNull(response.getPatronInfo());
   }
@@ -244,6 +238,66 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
     var response = responseEntity.getBody();
     assertFalse(response.getRequestAllowed());
     assertEquals(UNABLE_TO_VERIFY_PATRON,response.getReason());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"john doe","doe john","doe john"})
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
+    "classpath:db/user-custom-field-mapping/pre-populate-user-custom-field-mapping.sql"
+  })
+  void return200HttpCode_and_patronInfoResponseWithPatronInfo_hasIgnoreCaseCorrectOrderWithOutMiddleName_when_patronFoundAndRequestAllowed(String patronName) {
+    var user = createUser();
+    user.setPatronGroupId(UUID.fromString("54e17c4c-e315-4d20-8879-efc694dea1ce"));
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(1, List.of(user)));
+    when(automatedBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(manualBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(patronClient.getAccountDetails(any())).thenReturn(new PatronDTO());
+    when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
+
+    var patronInfoRequest = createPatronInfoRequest();
+    patronInfoRequest.setPatronName(patronName);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+
+    var response = responseEntity.getBody();
+    assertTrue(response.getRequestAllowed());
+    assertNotNull(response.getPatronInfo());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"john paul doe","doe john paul","doe John pauL"})
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
+    "classpath:db/user-custom-field-mapping/pre-populate-user-custom-field-mapping.sql"
+  })
+  void return200HttpCode_and_patronInfoResponseWithPatronInfo_hasIgnoreCaseCorrectOrderWithMiddleName_when_patronFoundAndRequestAllowed(String patronName) {
+    var user = createUserWithMiddleName();
+    user.setPatronGroupId(UUID.fromString("54e17c4c-e315-4d20-8879-efc694dea1ce"));
+    when(usersClient.query(anyString())).thenReturn(ResultList.of(1, List.of(user)));
+    when(automatedBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(manualBlocksClient.getPatronBlocks(any())).thenReturn(ResultList.empty());
+    when(patronClient.getAccountDetails(any())).thenReturn(new PatronDTO());
+    when(userCustomFieldService.getMapping(any())).thenReturn(createCustomFieldMapping());
+
+    var patronInfoRequest = createPatronInfoRequest();
+    patronInfoRequest.setPatronName(patronName);
+
+    var responseEntity = testRestTemplate.postForEntity(
+      "/inn-reach/d2ir/circ/verifypatron", new HttpEntity<>(patronInfoRequest, headers), PatronInfoResponseDTO.class);
+
+    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+    assertNotNull(responseEntity.getBody());
+
+    var response = responseEntity.getBody();
+    assertTrue(response.getRequestAllowed());
+    assertNotNull(response.getPatronInfo());
   }
 
   @Test


### PR DESCRIPTION
MODINREACH-315 (https://issues.folio.org/browse/MODINREACH-315)

## Purpose
1. Name matching should occur on a case-insensitive basis

## Approach
1. matchName() method updated to handle case-insensitive data for format ( firstName-lastName , lastName-firstName , middleName-lastName,LastName-middleName , FirstName-MiddleName-lastName and LastName-FirstName-MiddleName)
2. Testcase added 

## Output 
Find the attached docs: 

[MODINNREACH-315.docx](https://github.com/folio-org/mod-inn-reach/files/10077992/MODINNREACH-315.docx)

