### PR TITLE
Modinreach 327

### DIFF
--- a/src/main/java/org/folio/innreach/client/CirculationClient.java
+++ b/src/main/java/org/folio/innreach/client/CirculationClient.java
@@ -26,8 +26,12 @@ import org.folio.innreach.dto.LoanDTO;
 @FeignClient(name = "circulation", configuration = FolioFeignClientConfig.class, decode404 = true)
 public interface CirculationClient {
 
-  @GetMapping("/requests?query=(itemId=={itemId})")
+  @GetMapping("/requests?query=(itemId=={itemId}) and status==\"Open - Not yet filled\"")
   ResultList<RequestDTO> queryRequestsByItemId(@PathVariable("itemId") UUID itemId);
+
+  @GetMapping("/requests?query=(itemId=={itemId}) and status==(\"Open - Awaiting pickup\" or \"Open - Not yet filled\" or \"Open - In transit\" or \"Open - Awaiting delivery\" )")
+  ResultList<RequestDTO> queryRequestsByItemIdAndStatus(@PathVariable("itemId") UUID itemId);
+
 
   @GetMapping("/requests?query=id=({requestIds}) and status==\"Open - Not yet filled\"")
   ResultList<RequestDTO> queryNotFilledRequestsByIds(@PathVariable("requestIds") String requestIds, @RequestParam("limit") int limit);

--- a/src/main/java/org/folio/innreach/client/CirculationClient.java
+++ b/src/main/java/org/folio/innreach/client/CirculationClient.java
@@ -31,8 +31,8 @@ public interface CirculationClient {
 
   @GetMapping("/requests?query=(itemId=={itemId}) and " +
           "status==(\"Open - Awaiting pickup\" or \"Open - Not yet filled\" or \"Open - In transit\" or \"Open - Awaiting delivery\") " +
-          "sortby requestDate desc&limit=1")
-  ResultList<RequestDTO> queryRequestsByItemIdAndStatus(@PathVariable("itemId") UUID itemId);
+          "sortby requestDate desc")
+  ResultList<RequestDTO> queryRequestsByItemIdAndStatus(@PathVariable("itemId") UUID itemId,@RequestParam("limit") int limit);
 
 
   @GetMapping("/requests?query=id=({requestIds}) and status==\"Open - Not yet filled\"")

--- a/src/main/java/org/folio/innreach/client/CirculationClient.java
+++ b/src/main/java/org/folio/innreach/client/CirculationClient.java
@@ -26,7 +26,7 @@ import org.folio.innreach.dto.LoanDTO;
 @FeignClient(name = "circulation", configuration = FolioFeignClientConfig.class, decode404 = true)
 public interface CirculationClient {
 
-  @GetMapping("/requests?query=(itemId=={itemId}) and status==\"Open - Not yet filled\"")
+  @GetMapping("/requests?query=(itemId=={itemId})")
   ResultList<RequestDTO> queryRequestsByItemId(@PathVariable("itemId") UUID itemId);
 
   @GetMapping("/requests?query=(itemId=={itemId}) and status==(\"Open - Awaiting pickup\" or \"Open - Not yet filled\" or \"Open - In transit\" or \"Open - Awaiting delivery\" )")

--- a/src/main/java/org/folio/innreach/client/CirculationClient.java
+++ b/src/main/java/org/folio/innreach/client/CirculationClient.java
@@ -29,7 +29,9 @@ public interface CirculationClient {
   @GetMapping("/requests?query=(itemId=={itemId})")
   ResultList<RequestDTO> queryRequestsByItemId(@PathVariable("itemId") UUID itemId);
 
-  @GetMapping("/requests?query=(itemId=={itemId}) and status==(\"Open - Awaiting pickup\" or \"Open - Not yet filled\" or \"Open - In transit\" or \"Open - Awaiting delivery\" )")
+  @GetMapping("/requests?query=(itemId=={itemId}) and " +
+          "status==(\"Open - Awaiting pickup\" or \"Open - Not yet filled\" or \"Open - In transit\" or \"Open - Awaiting delivery\") " +
+          "sortby requestDate desc&limit=1")
   ResultList<RequestDTO> queryRequestsByItemIdAndStatus(@PathVariable("itemId") UUID itemId);
 
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -259,7 +259,7 @@ public class ContributionValidationServiceImpl implements ContributionValidation
   private boolean isItemAvailableForContribution(Item inventoryItem,
                                                  ItemContributionOptionsConfigurationDTO itemContributionConfig) {
     var itemStatus = inventoryItem.getStatus();
-
+    log.info("isItemAvailableForContribution : itemStatus : {}",itemStatus );
     if (itemStatus.getName() == IN_TRANSIT && isItemRequested(inventoryItem)) {
       return false;
     }
@@ -268,7 +268,9 @@ public class ContributionValidationServiceImpl implements ContributionValidation
   }
 
   private boolean isItemRequested(Item inventoryItem) {
+    log.info("isItemRequested : {} with status : {}", inventoryItem, inventoryItem.getStatus());
     var itemRequests = circulationClient.queryRequestsByItemId(inventoryItem.getId());
+    log.info("itemRequests.getTotalRecords() : {}", itemRequests.getTotalRecords());
     return itemRequests.getTotalRecords() != 0;
   }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -263,8 +263,13 @@ public class ContributionValidationServiceImpl implements ContributionValidation
   }
 
   private boolean isItemRequested(Item inventoryItem) {
-    var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId(),1);
-    return itemRequests.getTotalRecords() != 0;
+    try{
+      var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId(),1);
+      return itemRequests.getTotalRecords() != 0;
+    } catch (Exception e) {
+      log.warn("Unable to verify item is requested {}", e);
+      return false;
+    }
   }
 
   private List<UUID> getMaterialTypeIds() {

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -269,7 +269,7 @@ public class ContributionValidationServiceImpl implements ContributionValidation
 
   private boolean isItemRequested(Item inventoryItem) {
     log.info("isItemRequested : {} with status : {}", inventoryItem, inventoryItem.getStatus());
-    var itemRequests = circulationClient.queryRequestsByItemId(inventoryItem.getId());
+    var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId());
     log.info("itemRequests.getTotalRecords() : {}", itemRequests.getTotalRecords());
     return itemRequests.getTotalRecords() != 0;
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -263,13 +263,8 @@ public class ContributionValidationServiceImpl implements ContributionValidation
   }
 
   private boolean isItemRequested(Item inventoryItem) {
-    try{
-      var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId(),1);
-      return itemRequests.getTotalRecords() != 0;
-    } catch (Exception e) {
-      log.warn("Unable to verify item is requested {}", e);
-      return false;
-    }
+    var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId(),1);
+    return itemRequests.getTotalRecords() != 0;
   }
 
   private List<UUID> getMaterialTypeIds() {

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -142,6 +142,8 @@ public class ContributionValidationServiceImpl implements ContributionValidation
     var itemContributionConfig = itemContributionOptionsConfigurationService
       .getItmContribOptConf(centralServerId);
 
+    log.info("getItemCirculationStatus: itemContributionConfig {}", itemContributionConfig);
+
     if (isItemNonLendable(item, itemContributionConfig)) {
       return ContributionItemCirculationStatus.NON_LENDABLE;
     }
@@ -261,7 +263,7 @@ public class ContributionValidationServiceImpl implements ContributionValidation
     if (itemStatus.getName() == IN_TRANSIT && isItemRequested(inventoryItem)) {
       return false;
     }
-
+    log.info("isItemAvailableForContribution : itemContributionConfig : {}",itemContributionConfig );
     return itemStatus.getName() == AVAILABLE || !itemContributionConfig.getNotAvailableItemStatuses().contains(itemStatus.getName().getValue());
   }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -269,7 +269,7 @@ public class ContributionValidationServiceImpl implements ContributionValidation
 
   private boolean isItemRequested(Item inventoryItem) {
     log.info("isItemRequested : {} with status : {}", inventoryItem, inventoryItem.getStatus());
-    var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId());
+    var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId(),1);
     log.info("itemRequests.getTotalRecords() : {}", itemRequests.getTotalRecords());
     return itemRequests.getTotalRecords() != 0;
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImpl.java
@@ -1,28 +1,8 @@
 package org.folio.innreach.domain.service.impl;
 
-import static java.util.Collections.emptyList;
-import static org.apache.commons.collections4.ListUtils.emptyIfNull;
-
-import static org.folio.innreach.domain.service.impl.MARCRecordTransformationServiceImpl.isMARCRecord;
-import static org.folio.innreach.dto.ItemStatus.NameEnum.AVAILABLE;
-import static org.folio.innreach.dto.ItemStatus.NameEnum.CHECKED_OUT;
-import static org.folio.innreach.dto.ItemStatus.NameEnum.IN_TRANSIT;
-import static org.folio.innreach.dto.MappingValidationStatusDTO.INVALID;
-import static org.folio.innreach.dto.MappingValidationStatusDTO.VALID;
-import static org.folio.innreach.util.ListUtils.mapItems;
-
-import java.util.List;
-import java.util.Objects;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import lombok.AllArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.collections4.CollectionUtils;
-import org.folio.innreach.dto.LocalAgencyDTO;
-import org.springframework.stereotype.Service;
-import org.springframework.util.Assert;
-
 import org.folio.innreach.client.CirculationClient;
 import org.folio.innreach.client.MaterialTypesClient;
 import org.folio.innreach.domain.dto.folio.ContributionItemCirculationStatus;
@@ -44,6 +24,23 @@ import org.folio.innreach.dto.ItemContributionOptionsConfigurationDTO;
 import org.folio.innreach.dto.LibraryMappingDTO;
 import org.folio.innreach.dto.MappingValidationStatusDTO;
 import org.folio.innreach.external.service.InnReachLocationExternalService;
+import org.springframework.stereotype.Service;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static java.util.Collections.emptyList;
+import static org.apache.commons.collections4.ListUtils.emptyIfNull;
+import static org.folio.innreach.domain.service.impl.MARCRecordTransformationServiceImpl.isMARCRecord;
+import static org.folio.innreach.dto.ItemStatus.NameEnum.AVAILABLE;
+import static org.folio.innreach.dto.ItemStatus.NameEnum.CHECKED_OUT;
+import static org.folio.innreach.dto.ItemStatus.NameEnum.IN_TRANSIT;
+import static org.folio.innreach.dto.MappingValidationStatusDTO.INVALID;
+import static org.folio.innreach.dto.MappingValidationStatusDTO.VALID;
+import static org.folio.innreach.util.ListUtils.mapItems;
 
 @Log4j2
 @AllArgsConstructor
@@ -141,8 +138,6 @@ public class ContributionValidationServiceImpl implements ContributionValidation
   public ContributionItemCirculationStatus getItemCirculationStatus(UUID centralServerId, Item item) {
     var itemContributionConfig = itemContributionOptionsConfigurationService
       .getItmContribOptConf(centralServerId);
-
-    log.info("getItemCirculationStatus: itemContributionConfig {}", itemContributionConfig);
 
     if (isItemNonLendable(item, itemContributionConfig)) {
       return ContributionItemCirculationStatus.NON_LENDABLE;
@@ -259,18 +254,16 @@ public class ContributionValidationServiceImpl implements ContributionValidation
   private boolean isItemAvailableForContribution(Item inventoryItem,
                                                  ItemContributionOptionsConfigurationDTO itemContributionConfig) {
     var itemStatus = inventoryItem.getStatus();
-    log.info("isItemAvailableForContribution : itemStatus : {}",itemStatus );
+
     if (itemStatus.getName() == IN_TRANSIT && isItemRequested(inventoryItem)) {
       return false;
     }
-    log.info("isItemAvailableForContribution : itemContributionConfig : {}",itemContributionConfig );
+
     return itemStatus.getName() == AVAILABLE || !itemContributionConfig.getNotAvailableItemStatuses().contains(itemStatus.getName().getValue());
   }
 
   private boolean isItemRequested(Item inventoryItem) {
-    log.info("isItemRequested : {} with status : {}", inventoryItem, inventoryItem.getStatus());
     var itemRequests = circulationClient.queryRequestsByItemIdAndStatus(inventoryItem.getId(),1);
-    log.info("itemRequests.getTotalRecords() : {}", itemRequests.getTotalRecords());
     return itemRequests.getTotalRecords() != 0;
   }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/RecordTransformationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/RecordTransformationServiceImpl.java
@@ -104,8 +104,6 @@ public class RecordTransformationServiceImpl implements RecordTransformationServ
       var suppressionStatus = getSuppressionStatus(centralServerId, item);
       var circulationStatus = getCirculationStatus(centralServerId, item);
 
-      log.info("Item {} circulation status {}", item.getBarcode(), circulationStatus);
-
       var copyNumber = Optional.ofNullable(item.getCopyNumber())
         .map(n -> n.replaceAll(NON_DIGIT_REGEX, ""))
         .filter(NumberUtils::isCreatable)

--- a/src/main/java/org/folio/innreach/domain/service/impl/RecordTransformationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/RecordTransformationServiceImpl.java
@@ -104,6 +104,8 @@ public class RecordTransformationServiceImpl implements RecordTransformationServ
       var suppressionStatus = getSuppressionStatus(centralServerId, item);
       var circulationStatus = getCirculationStatus(centralServerId, item);
 
+      log.info("Item {} circulation status {}", item.getBarcode(), circulationStatus);
+
       var copyNumber = Optional.ofNullable(item.getCopyNumber())
         .map(n -> n.replaceAll(NON_DIGIT_REGEX, ""))
         .filter(NumberUtils::isCreatable)

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
@@ -112,7 +112,8 @@ class ContributionValidationServiceImplTest {
   @Test
   void returnAvailableContributionStatusWhenItemStatusIsInTransitAndItemIsNotRequested() {
     var itemContributionConfigOptions =
-            deserializeFromJsonFile( "/item-contribution-options/item-contribution-config-options.json", ItemContributionOptionsConfigurationDTO.class);
+            deserializeFromJsonFile( "/item-contribution-options/item-contribution-config-options.json",
+                    ItemContributionOptionsConfigurationDTO.class);
     when(itemContributionOptionsConfigurationService.getItmContribOptConf(any())).
             thenReturn(itemContributionConfigOptions);
 

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
@@ -116,9 +116,7 @@ class ContributionValidationServiceImplTest {
     when(itemContributionOptionsConfigurationService.getItmContribOptConf(any())).
             thenReturn(itemContributionConfigOptions);
 
-//    var item = createItem();
     var item = deserializeFromJsonFile( "/item/item-in-transit.json", Item.class);
-//    item.setStatus(new ItemStatus().name(ItemStatus.NameEnum.IN_TRANSIT));
     item.setPermanentLoanTypeId(UUID.fromString("2b94c631-fca9-4892-a730-03ee529ffe27"));
     item.setTemporaryLoanTypeId(UUID.fromString("2b94c631-fca9-4892-a730-03ee529ffe27"));
     item.setEffectiveLocationId(UUID.fromString("fcd64ce1-6995-48f0-840e-89ffa2288371"));

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.when;
 
 import static org.folio.innreach.fixture.ContributionFixture.createContributionCriteria;
@@ -123,7 +124,7 @@ class ContributionValidationServiceImplTest {
     item.setEffectiveLocationId(UUID.fromString("fcd64ce1-6995-48f0-840e-89ffa2288371"));
     item.setMaterialTypeId(UUID.fromString("1a54b431-2e4f-452d-9cae-9cee66c9a892"));
 
-    when(circulationClient.queryRequestsByItemIdAndStatus(any())).thenReturn(ResultList.of(0, Collections.emptyList()));
+    when(circulationClient.queryRequestsByItemIdAndStatus(any(),anyInt())).thenReturn(ResultList.of(0, Collections.emptyList()));
 
     var itemCirculationStatus = service.getItemCirculationStatus(UUID.randomUUID(), item);
 
@@ -137,7 +138,7 @@ class ContributionValidationServiceImplTest {
     var item = createItem();
     item.setStatus(new ItemStatus().name(ItemStatus.NameEnum.IN_TRANSIT));
 
-    when(circulationClient.queryRequestsByItemIdAndStatus(any())).thenReturn(ResultList.of(1, List.of(new RequestDTO())));
+    when(circulationClient.queryRequestsByItemIdAndStatus(any(),anyInt())).thenReturn(ResultList.of(1, List.of(new RequestDTO())));
 
     var itemCirculationStatus = service.getItemCirculationStatus(UUID.randomUUID(), item);
 

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
@@ -123,7 +123,7 @@ class ContributionValidationServiceImplTest {
     item.setEffectiveLocationId(UUID.fromString("fcd64ce1-6995-48f0-840e-89ffa2288371"));
     item.setMaterialTypeId(UUID.fromString("1a54b431-2e4f-452d-9cae-9cee66c9a892"));
 
-    when(circulationClient.queryRequestsByItemId(any())).thenReturn(ResultList.of(0, Collections.emptyList()));
+    when(circulationClient.queryRequestsByItemIdAndStatus(any())).thenReturn(ResultList.of(0, Collections.emptyList()));
 
     var itemCirculationStatus = service.getItemCirculationStatus(UUID.randomUUID(), item);
 
@@ -137,7 +137,7 @@ class ContributionValidationServiceImplTest {
     var item = createItem();
     item.setStatus(new ItemStatus().name(ItemStatus.NameEnum.IN_TRANSIT));
 
-    when(circulationClient.queryRequestsByItemId(any())).thenReturn(ResultList.of(1, List.of(new RequestDTO())));
+    when(circulationClient.queryRequestsByItemIdAndStatus(any())).thenReturn(ResultList.of(1, List.of(new RequestDTO())));
 
     var itemCirculationStatus = service.getItemCirculationStatus(UUID.randomUUID(), item);
 

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
@@ -111,13 +111,10 @@ class ContributionValidationServiceImplTest {
 
   @Test
   void returnAvailableContributionStatusWhenItemStatusIsInTransitAndItemIsNotRequested() {
-    var itemContributionConfigOptions =
-            deserializeFromJsonFile( "/item-contribution-options/item-contribution-config-options.json",
-                    ItemContributionOptionsConfigurationDTO.class);
-    when(itemContributionOptionsConfigurationService.getItmContribOptConf(any())).
-            thenReturn(itemContributionConfigOptions);
+    when(itemContributionOptionsConfigurationService.getItmContribOptConf(any())).thenReturn(createItmContribOptConfDTO());
 
-    var item = deserializeFromJsonFile( "/item/item-in-transit.json", Item.class);
+    var item = createItem();
+    item.setStatus(new ItemStatus().name(ItemStatus.NameEnum.IN_TRANSIT));
     item.setPermanentLoanTypeId(UUID.fromString("2b94c631-fca9-4892-a730-03ee529ffe27"));
     item.setTemporaryLoanTypeId(UUID.fromString("2b94c631-fca9-4892-a730-03ee529ffe27"));
     item.setEffectiveLocationId(UUID.fromString("fcd64ce1-6995-48f0-840e-89ffa2288371"));

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionValidationServiceImplTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import static org.folio.innreach.fixture.ContributionFixture.createContributionCriteria;
 import static org.folio.innreach.fixture.ContributionFixture.createItem;
 import static org.folio.innreach.fixture.ItemContributionOptionsConfigurationFixture.createItmContribOptConfDTO;
+import static org.folio.innreach.fixture.TestUtil.deserializeFromJsonFile;
 
 import java.util.Collections;
 import java.util.List;
@@ -22,6 +23,7 @@ import java.util.UUID;
 
 import lombok.extern.log4j.Log4j2;
 import org.folio.innreach.dto.CentralServerDTO;
+import org.folio.innreach.dto.ItemContributionOptionsConfigurationDTO;
 import org.folio.innreach.dto.LocalAgencyDTO;
 import org.folio.innreach.fixture.CentralServerFixture;
 import org.junit.jupiter.api.BeforeEach;
@@ -108,10 +110,18 @@ class ContributionValidationServiceImplTest {
 
   @Test
   void returnAvailableContributionStatusWhenItemStatusIsInTransitAndItemIsNotRequested() {
-    when(itemContributionOptionsConfigurationService.getItmContribOptConf(any())).thenReturn(createItmContribOptConfDTO());
+    var itemContributionConfigOptions =
+            deserializeFromJsonFile( "/item-contribution-options/item-contribution-config-options.json", ItemContributionOptionsConfigurationDTO.class);
+    when(itemContributionOptionsConfigurationService.getItmContribOptConf(any())).
+            thenReturn(itemContributionConfigOptions);
 
-    var item = createItem();
-    item.setStatus(new ItemStatus().name(ItemStatus.NameEnum.IN_TRANSIT));
+//    var item = createItem();
+    var item = deserializeFromJsonFile( "/item/item-in-transit.json", Item.class);
+//    item.setStatus(new ItemStatus().name(ItemStatus.NameEnum.IN_TRANSIT));
+    item.setPermanentLoanTypeId(UUID.fromString("2b94c631-fca9-4892-a730-03ee529ffe27"));
+    item.setTemporaryLoanTypeId(UUID.fromString("2b94c631-fca9-4892-a730-03ee529ffe27"));
+    item.setEffectiveLocationId(UUID.fromString("fcd64ce1-6995-48f0-840e-89ffa2288371"));
+    item.setMaterialTypeId(UUID.fromString("1a54b431-2e4f-452d-9cae-9cee66c9a892"));
 
     when(circulationClient.queryRequestsByItemId(any())).thenReturn(ResultList.of(0, Collections.emptyList()));
 

--- a/src/test/resources/json/item/item-in-transit.json
+++ b/src/test/resources/json/item/item-in-transit.json
@@ -1,0 +1,64 @@
+{
+  "id" : "985c909e-e934-44b7-8247-e65d30da7b64",
+  "_version" : "38",
+  "status" : {
+    "name" : "In transit",
+    "date" : "2022-11-21T09:29:33.493+00:00"
+  },
+  "administrativeNotes" : [ ],
+  "title" : "Battle ground : a novel of the Dresden files / Jim Butcher.",
+  "callNumber" : "PS3602.U85",
+  "hrid" : "it00000000024",
+  "inTransitDestinationServicePointId" : "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+  "contributorNames" : [ {
+    "name" : "Butcher, Jim, 1971-"
+  } ],
+  "formerIds" : [ ],
+  "discoverySuppress" : null,
+  "holdingsRecordId" : "a562a769-c0f7-4cdb-a22f-8e90b97114c2",
+  "barcode" : "BATTLE1",
+  "volume" : "Volume-1",
+  "notes" : [ ],
+  "circulationNotes" : [ ],
+  "tags" : {
+    "tagList" : [ ]
+  },
+  "yearCaption" : [ ],
+  "electronicAccess" : [ ],
+  "statisticalCodeIds" : [ ],
+  "purchaseOrderLineIdentifier" : null,
+  "materialType" : {
+    "id" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+    "name" : "book"
+  },
+  "permanentLoanType" : {
+    "id" : "2b94c631-fca9-4892-a730-03ee529ffe27",
+    "name" : "Can circulate"
+  },
+  "metadata" : {
+    "createdDate" : "2022-02-22T22:49:33.549+00:00",
+    "createdByUserId" : "8e75dcb2-db5f-53a7-a09e-7084c47b7ece",
+    "updatedDate" : "2022-11-21T09:29:33.490+00:00",
+    "updatedByUserId" : "8e75dcb2-db5f-53a7-a09e-7084c47b7ece"
+  },
+  "links" : {
+    "self" : "http://volaris-okapi.ci.folio.org/inventory/items/985c909e-e934-44b7-8247-e65d30da7b64"
+  },
+  "lastCheckIn" : {
+    "servicePointId" : "7c5abc9f-f3d7-4856-b8d7-6712462ca007",
+    "staffMemberId" : "8e75dcb2-db5f-53a7-a09e-7084c47b7ece",
+    "dateTime" : "2022-11-21T09:29:32.955Z"
+  },
+  "effectiveCallNumberComponents" : {
+    "callNumber" : "PS3602.U85",
+    "prefix" : null,
+    "suffix" : null,
+    "typeId" : null
+  },
+  "effectiveShelvingOrder" : "PS 43602 U85 VOLUME 11",
+  "isBoundWith" : false,
+  "effectiveLocation" : {
+    "id" : "fcd64ce1-6995-48f0-840e-89ffa2288371",
+    "name" : "Main Library"
+  }
+}


### PR DESCRIPTION
[MODINREACH-327](https://issues.folio.org/browse/MODINREACH-327)

## Purpose

INN-Reach: Item's "in-transit" should be "Available" in INN-Reach if there are no open requests on the item.

## Approach
As per my analysis, When the item is checked in and put in-transit, an automatic update triggers ongoing contribution, which internally prepares/updates the item object and contributes to the service catalog. But here in the contribution process, it confirms whether in-transit item is requested or not through just counts of request(s).

And, the check implemented here should check only open requests which are having status "Open - Awaiting pickup" or "Open - Not yet filled" or "Open - In transit" or "Open - Awaiting delivery", but it also considers requests which are having status Closed - Filled, Closed - Cancelled, Closed - Unfilled, Closed - Pickup expired  

Due to this item is considered as requested even with closed requests, and Item's updated contribution status shows as UNAVAILABLE on the service catalog ([https://d2irm.iii.com/)](https://d2irm.iii.com/)*_)

Even on the Inventory Item Page, which shows the number of requests for the item that only shows request-count which with any of "Open - Awaiting pickup", "Open - Not yet filled", "Open - In transit", "Open - Awaiting delivery".

**Finally, decided to consider only “Open - …” requests.**

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
