### PR TITLE
MODINREACH-346: Upgrade folio-spring-base, Spring, snakeyaml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.6</version>
     <relativePath />
   </parent>
   <groupId>org.folio</groupId>
@@ -22,12 +22,13 @@
 
   <properties>
     <!-- runtime dependencies -->
-    <folio-spring-base.version>5.0.2</folio-spring-base.version>
-    <spring-cloud-starter-openfeign.version>3.1.2</spring-cloud-starter-openfeign.version>
+    <folio-spring-base.version>5.0.3</folio-spring-base.version>
+    <spring-cloud-starter-openfeign.version>3.1.5</spring-cloud-starter-openfeign.version>
     <commons-collections4.version>4.4</commons-collections4.version>
     <mapstruct.version>1.5.1.Final</mapstruct.version>
     <marc4j.version>2.9.2</marc4j.version>
     <coffee-boots.version>3.0.0</coffee-boots.version>
+    <snakeyaml.version>1.33</snakeyaml.version>
 
     <!-- test dependencies -->
     <testcontainers.version>1.17.2</testcontainers.version>


### PR DESCRIPTION
Upgrade folio-spring-base from 5.0.2 to 5.0.3.

Upgrade Spring Boot from 2.7.3 to 2.7.6.

Upgrade spring-cloud-starter-openfeign from 3.1.2 to 3.1.5.

Upgrade snakeyaml from 1.30 to 1.33.

The Spring Boot upgrade fixes Authorization Bypass:

https://www.cve.org/CVERecord?id=CVE-2022-31692

The Spring Boot upgrade indirectly upgrades Jackson from 2.13.3 to 2.13.4.2 fixing Denial of Service (DoS):

https://www.cve.org/CVERecord?id=CVE-2022-42004
https://www.cve.org/CVERecord?id=CVE-2022-42003

The Spring Boot upgrade indirectly removes the unused dependency jettison 1.2 that has a Denial of Service (DoS) vulnerability:

https://www.cve.org/CVERecord?id=CVE-2022-45685

The Spring Boot upgrade indirectly upgrades Postgresql from 42.3.6 to 42.3.8 fixing SQL Injection and Information Exposure:

https://www.cve.org/CVERecord?id=CVE-2022-31197
https://www.cve.org/CVERecord?id=CVE-2022-41946

Upgrading snakeyaml from 1.30 to 1.33 fixes Denial of Service (DoS) and Stack-based Buffer Overflow:

https://www.cve.org/CVERecord?id=CVE-2022-25857
https://www.cve.org/CVERecord?id=CVE-2022-38749
https://www.cve.org/CVERecord?id=CVE-2022-38751
https://www.cve.org/CVERecord?id=CVE-2022-38752
https://www.cve.org/CVERecord?id=CVE-2022-38750
https://www.cve.org/CVERecord?id=CVE-2022-41854

The folio-spring-base upgrade is made to match the Spring version.