### PR TITLE
MODINREACH-398 Allow Tenant Collection Topics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 
   <properties>
     <!-- runtime dependencies -->
+    <folio-service-tools.version>3.1.0-SNAPSHOT</folio-service-tools.version>
     <folio-spring-base.version>7.0.0</folio-spring-base.version>
     <folio-spring-system-user.version>7.2.0-SNAPSHOT</folio-spring-system-user.version>
     <spring-cloud-starter-openfeign.version>4.0.0</spring-cloud-starter-openfeign.version>
@@ -70,6 +71,11 @@
   </properties>
 
   <dependencies>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-service-tools-spring-dev</artifactId>
+      <version>${folio-service-tools.version}</version>
+    </dependency>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-spring-base</artifactId>

--- a/src/main/java/org/folio/innreach/batch/contribution/IterationEventReaderFactory.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/IterationEventReaderFactory.java
@@ -19,6 +19,7 @@ import org.folio.innreach.batch.contribution.listener.ContributionExceptionListe
 import org.folio.innreach.batch.contribution.service.ContributionJobRunner;
 import org.folio.innreach.config.RetryConfig;
 import org.folio.spring.config.properties.FolioEnvironment;
+import org.folio.spring.tools.kafka.KafkaUtils;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.kafka.KafkaProperties;
@@ -102,8 +103,7 @@ public class IterationEventReaderFactory {
   }
 
   public String getTopicName(String tenantId) {
-    return String.format("%s.%s.%s",
-      folioEnv.getEnvironment(), tenantId, jobProperties.getReaderTopic());
+    return KafkaUtils.getTenantTopicName(jobProperties.getReaderTopic(), folioEnv.getEnvironment(), tenantId);
   }
 
 }

--- a/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
@@ -16,7 +16,7 @@ import com.google.common.collect.Iterables;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
-import org.folio.innreach.domain.service.impl.FolioExecutionContextBuilder;
+import org.folio.innreach.domain.service.impl.InnReachFolioExecutionContextBuilder;
 import org.folio.spring.scope.FolioExecutionContextSetter;
 import org.folio.innreach.external.exception.InnReachConnectionException;
 import org.folio.innreach.external.exception.ServiceSuspendedException;
@@ -66,7 +66,7 @@ public class ContributionJobRunner {
   private final Statistics stats = new Statistics();
 
   private static final List<UUID> runningInitialContributions = Collections.synchronizedList(new ArrayList<>());
-  private final FolioExecutionContextBuilder folioExecutionContextBuilder;
+  private final InnReachFolioExecutionContextBuilder folioExecutionContextBuilder;
 
   private static Map<String,Integer> totalRecords = new HashMap<>();
   private static ConcurrentHashMap<String, Integer> recordsProcessed = new ConcurrentHashMap<>();

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachFolioExecutionContextBuilder.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachFolioExecutionContextBuilder.java
@@ -19,7 +19,8 @@ import org.folio.spring.FolioModuleMetadata;
 @Component
 @RequiredArgsConstructor
 @Log4j2
-public class FolioExecutionContextBuilder {
+public class InnReachFolioExecutionContextBuilder {
+  // TODO: merge this class with similar named FolioExecutionContextBuilder in folio-service-tools
   private final FolioModuleMetadata moduleMetadata;
 
   public Builder builder() {

--- a/src/main/java/org/folio/innreach/domain/service/impl/TenantScopedExecutionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/TenantScopedExecutionService.java
@@ -12,7 +12,7 @@ import org.folio.spring.service.SystemUserService;
 @RequiredArgsConstructor
 public class TenantScopedExecutionService {
 
-  private final FolioExecutionContextBuilder contextBuilder;
+  private final InnReachFolioExecutionContextBuilder contextBuilder;
   private final SystemUserService systemUserService;
 
   @SneakyThrows

--- a/src/test/java/org/folio/innreach/batch/contribution/service/ContributionJobRunnerTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/ContributionJobRunnerTest.java
@@ -26,7 +26,7 @@ import java.net.SocketTimeoutException;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.folio.innreach.domain.service.impl.FolioExecutionContextBuilder;
+import org.folio.innreach.domain.service.impl.InnReachFolioExecutionContextBuilder;
 import feign.FeignException;
 import org.folio.innreach.batch.contribution.InitialContributionJobConsumerContainer;
 import org.folio.innreach.external.exception.InnReachConnectionException;
@@ -109,7 +109,7 @@ class ContributionJobRunnerTest {
   private ContributionJobRunner jobRunner;
 
   @Mock
-  private FolioExecutionContextBuilder folioExecutionContextBuilder;
+  private InnReachFolioExecutionContextBuilder folioExecutionContextBuilder;
 
   @Mock
   private InitialContributionJobConsumerContainer initialContributionJobConsumerContainer;

--- a/src/test/java/org/folio/innreach/domain/service/impl/FolioExecutionContextBuilderTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/FolioExecutionContextBuilderTest.java
@@ -19,8 +19,8 @@ class FolioExecutionContextBuilderTest {
 
   private final FolioExecutionContext folioExecutionContext = mock(FolioExecutionContext.class);
   private final FolioModuleMetadata folioModuleMetadata = mock(FolioModuleMetadata.class);
-  private final FolioExecutionContextBuilder builder =
-    new FolioExecutionContextBuilder(mock(FolioModuleMetadata.class));
+  private final InnReachFolioExecutionContextBuilder builder =
+    new InnReachFolioExecutionContextBuilder(mock(FolioModuleMetadata.class));
 
 
   @Test

--- a/src/test/java/org/folio/innreach/fixture/FolioContextFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/FolioContextFixture.java
@@ -7,7 +7,7 @@ import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 
 import org.mockito.Mockito;
 
-import org.folio.innreach.domain.service.impl.FolioExecutionContextBuilder;
+import org.folio.innreach.domain.service.impl.InnReachFolioExecutionContextBuilder;
 import org.folio.spring.service.SystemUserService;
 import org.folio.innreach.domain.service.impl.TenantScopedExecutionService;
 import org.folio.spring.DefaultFolioExecutionContext;
@@ -17,11 +17,11 @@ public class FolioContextFixture {
   public static final DefaultFolioExecutionContext FOLIO_CONTEXT =
     new DefaultFolioExecutionContext(null, singletonMap(TENANT, singletonList("test")));
 
-  private static final FolioExecutionContextBuilder contextBuilder = Mockito.mock(FolioExecutionContextBuilder.class);
+  private static final InnReachFolioExecutionContextBuilder contextBuilder = Mockito.mock(InnReachFolioExecutionContextBuilder.class);
   private static final SystemUserService systemUserService = Mockito.mock(SystemUserService.class);
 
   public static TenantScopedExecutionService createTenantExecutionService() {
-    return new TenantScopedExecutionService(Mockito.mock(FolioExecutionContextBuilder.class), Mockito.mock(SystemUserService.class));
+    return new TenantScopedExecutionService(Mockito.mock(InnReachFolioExecutionContextBuilder.class), Mockito.mock(SystemUserService.class));
   }
 
 }


### PR DESCRIPTION
## Purpose
Allow tenant collection topics to be configurable. Tenant collection topics means a module will use a single topic for many tenants for the same event type.

## Approach
Pulled in the folio-service-tools library and used a utility to generate the topic name