### PR TITLE
MODINREACH-424: Patron validation endpoint should strip commas and leading and trailing spaces from the patron name field

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
@@ -12,7 +12,11 @@ import static org.folio.innreach.external.dto.InnReachResponse.Error.ofMessage;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PatronInfoServiceImpl.java
@@ -12,9 +12,7 @@ import static org.folio.innreach.external.dto.InnReachResponse.Error.ofMessage;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Date;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
@@ -226,7 +224,16 @@ public class PatronInfoServiceImpl implements PatronInfoService {
 
   private static boolean matchName(User user, String patronName) {
     var personal = user.getPersonal();
-    String[] patronNameTokens = patronName.replace(",", "").split("\\s");
+    String[] patronNameTokens = nonNullStrip(patronName).replace(",", "").split("\\s");
+
+    for (int i = 0; i < patronNameTokens.length; i++) {
+      patronNameTokens[i] = patronNameTokens[i].strip();
+    }
+
+    // Because split can return empty strings on sequences of spaces.
+    patronNameTokens = Arrays.stream(patronNameTokens)
+      .filter(str -> !str.isEmpty())
+      .toArray(String[]::new);
 
     if (patronNameTokens.length < 2) {
       return false;
@@ -241,19 +248,28 @@ public class PatronInfoServiceImpl implements PatronInfoService {
       || checkFirstNameMiddleNameLastNameWithPosition(personal, patronNameTokens,1,2,0));
   }
 
-  private static boolean checkFirstNameMiddleNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,
-                                                                      int firstNamePosition,int middleNamePosition,int lastNamePosition) {
 
-    boolean checkFirstName = equalsAnyIgnoreCase(patronNameTokens[firstNamePosition], personal.getFirstName(), personal.getPreferredFirstName());
-    boolean checkMiddleName = patronNameTokens[middleNamePosition].equalsIgnoreCase(personal.getMiddleName());
-    boolean checkLastName = patronNameTokens[lastNamePosition].equalsIgnoreCase(personal.getLastName());
+  private static boolean checkFirstNameMiddleNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,
+                                                                      int firstNamePosition, int middleNamePosition,
+                                                                      int lastNamePosition) {
+
+    boolean checkFirstName = equalsAnyIgnoreCase(patronNameTokens[firstNamePosition],
+      nonNullStrip(personal.getFirstName()), nonNullStrip(personal.getPreferredFirstName()));
+    boolean checkMiddleName = patronNameTokens[middleNamePosition].equalsIgnoreCase(nonNullStrip(personal.getMiddleName()));
+    boolean checkLastName = patronNameTokens[lastNamePosition].equalsIgnoreCase(nonNullStrip(personal.getLastName()));
     return checkFirstName && checkMiddleName && checkLastName;
   }
 
-  private static boolean checkFirstNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,int firstNamePos,int lastNamePos) {
-    boolean checkFirstName = equalsAnyIgnoreCase(patronNameTokens[firstNamePos], personal.getFirstName(), personal.getPreferredFirstName(), personal.getMiddleName());
-    boolean checkLastName = patronNameTokens[lastNamePos].equalsIgnoreCase(personal.getLastName());
+  private static boolean checkFirstNameLastNameWithPosition(User.Personal personal, String[] patronNameTokens,
+                                                            int firstNamePos, int lastNamePos) {
+    boolean checkFirstName = equalsAnyIgnoreCase(patronNameTokens[firstNamePos], nonNullStrip(personal.getFirstName()),
+      nonNullStrip(personal.getPreferredFirstName()), nonNullStrip(personal.getMiddleName()));
+    boolean checkLastName = patronNameTokens[lastNamePos].equalsIgnoreCase(nonNullStrip(personal.getLastName()));
     return (checkFirstName && checkLastName);
+  }
+
+  private static String nonNullStrip(String s) {
+    return Objects.requireNonNullElse(s, "").strip();
   }
 
   private static String getPatronName(User user) {

--- a/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/PatronInfoControllerTest.java
@@ -273,8 +273,9 @@ class PatronInfoControllerTest extends BaseApiControllerTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"john paul doe","doe john paul","doe John pauL","doe, John pauL","doe John, pauL","doe John pauL,",
-    "doe, John, pauL", "doe John, pauL,", ",doe, John, pauL,"})
+  @ValueSource(strings = {"john paul doe","doe john paul","doe John pauL","doe, John pauL","doe John, pauL",
+    "doe John pauL,", "doe, John, pauL", "doe John, pauL,", ",doe, John, pauL,", "John, Doe "," John, Doe ",
+    "  Doe,   John    ", " John  paul  doe "})
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINREACH-424

The ticket was reopened and I added a new requirement to it which is to strip leading and trailing spaces and changed the title to reflect that. This PR covers only removing the leading and trailing spaces.