### PR TITLE
MODINREACH-453 Update module permission

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## v3.X.X (Unreleased)
+
+### Stories
+* [MODINREACH-453](https://folio-org.atlassian.net/browse/MODINREACH-453) - Replace source-storage.records.get permission with source-storage.records.formatted.item.get
+
 ## v3.2.0 2024-03-20
 
 ### Stories
@@ -10,7 +15,6 @@
 * [MODINREACH-423](https://issues.folio.org/browse/MODINREACH-423) - Final check in operation is missing configuration permission
 * [MODINREACH-424](https://issues.folio.org/browse/MODINREACH-424) - Patron validation endpoint should strip commas and leading and trailing spaces from the patron name field
 * [MODINREACH-420](https://issues.folio.org/browse/MODINREACH-420) - Update Spring version for Quesnelia
-* [MODINREACH-453](https://folio-org.atlassian.net/browse/MODINREACH-453) - Replace source-storage.records.get permission with source-storage.records.formatted.item.get
 
 
 ## v3.1.0 2023-10-12

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * [MODINREACH-423](https://issues.folio.org/browse/MODINREACH-423) - Final check in operation is missing configuration permission
 * [MODINREACH-424](https://issues.folio.org/browse/MODINREACH-424) - Patron validation endpoint should strip commas and leading and trailing spaces from the patron name field
 * [MODINREACH-420](https://issues.folio.org/browse/MODINREACH-420) - Update Spring version for Quesnelia
+* [MODINREACH-453](https://folio-org.atlassian.net/browse/MODINREACH-453) - Replace source-storage.records.get permission with source-storage.records.formatted.item.get
 
 
 ## v3.1.0 2023-10-12

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "inventory",
-      "version": "13.4"
+      "version": "13.1"
     },
     {
       "id": "service-points-users",
@@ -48,7 +48,7 @@
     },
     {
       "id": "source-storage-records",
-      "version": "3.2"
+      "version": "3.3"
     },
     {
       "id": "feesfines",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -20,7 +20,7 @@
     },
     {
       "id": "inventory",
-      "version": "13.1"
+      "version": "13.4"
     },
     {
       "id": "service-points-users",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -283,7 +283,7 @@
             "inventory-storage.inventory-view.instances.collection.get",
             "inventory-storage.material-types.collection.get",
             "inventory-storage.locations.collection.get",
-            "source-storage.records.get"
+            "source-storage.records.formatted.item.get"
           ]
         },
         {
@@ -347,7 +347,7 @@
           "permissionsRequired": ["inn-reach.d2ir.bib-info.item.get"],
           "modulePermissions": [
             "inventory-storage.inventory-view.instances.collection.get",
-            "source-storage.records.get"
+            "source-storage.records.formatted.item.get"
           ]
         },
         {
@@ -541,7 +541,7 @@
           "permissionsRequired": ["inn-reach.marc-record-transformation.item.get"],
           "modulePermissions": [
             "inventory-storage.instances.item.get",
-            "source-storage.records.get"
+            "source-storage.records.formatted.item.get"
           ]
         },
         {
@@ -1253,7 +1253,7 @@
         "inventory.instances.item.get",
         "users.collection.get",
         "users.item.get",
-        "source-storage.records.get",
+        "source-storage.records.formatted.item.get",
         "circulation.requests.item.get",
         "circulation.requests.collection.get",
         "circulation.loans.collection.get",

--- a/src/main/resources/permissions/mod-innreach.csv
+++ b/src/main/resources/permissions/mod-innreach.csv
@@ -10,7 +10,7 @@ inventory.items.item.get
 inventory.instances.item.get
 users.collection.get
 users.item.get
-source-storage.records.get
+source-storage.records.formatted.item.get
 circulation.requests.item.get
 circulation.requests.collection.get
 circulation.loans.collection.get


### PR DESCRIPTION
[MODINREACH-453](https://folio-org.atlassian.net/browse/MODINREACH-453) Rename source-storage.records.get module permission  

## Purpose
According to the epic https://folio-org.atlassian.net/browse/FOLIO-4044, some permissions have been changed in the mod-source-record-storage.

mod-inn-reach uses the permission source-storage.records.get for /records/{instanceId}/formatted endpoint. 
It should be replaced with source-storage.records.formatted.item.get 


## Learning
[Migration of Static Permissions Upon Upgrade](https://folio-org.atlassian.net/wiki/spaces/TC/pages/5055284/DR-000014+-+Migration+of+Static+Permissions+Upon+Upgrade)

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [x] Did any of the interface versions change?
  - [x] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?
