### PR TITLE
MODINREACH-468 - Code changes for the NPE

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -108,21 +108,14 @@ public class AgencyMappingServiceImpl implements AgencyMappingService {
   private Optional<UUID> getLocationIdByAgencyCode(AgencyLocationMappingDTO mapping, String agencyCode) {
     log.info("getLocationIdByAgencyCode:: Start - parameters mapping: {}, agencyCode: {}", mapping, agencyCode);
 
-    if (mapping == null || mapping.getLocalServers() == null) {
-      log.warn("getLocationIdByAgencyCode:: mapping or localServers is null. Returning Optional.empty()");
-      return Optional.empty();
-    }
-
-    log.info("getLocationIdByAgencyCode:: Found localServers. Processing mappings.");
-
     Optional<UUID> locationId = mapping.getLocalServers().stream()
       .filter(Objects::nonNull)
       .map(server -> {
-        if (server.getAgencyCodeMappings() == null) {
+        if (server.getAgencyCodeMappings() == null || server.getAgencyCodeMappings().isEmpty()) {
           log.warn("getLocationIdByAgencyCode:: agencyCodeMappings is null for server: {}. Skipping this server.", server);
           return null;
         }
-        log.debug("getLocationIdByAgencyCode:: Processing agencyCodeMappings for server: {}", server);
+        log.info("getLocationIdByAgencyCode:: Processing agencyCodeMappings for server: {}", server);
         return server.getAgencyCodeMappings();
       })
       .filter(Objects::nonNull)

--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -2,7 +2,11 @@ package org.folio.innreach.domain.service.impl;
 
 import static org.folio.innreach.domain.service.impl.ServiceUtils.merge;
 
-import java.util.*;
+import java.util.Collection;	import java.util.*;
+import java.util.Comparator;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
@@ -16,7 +20,6 @@ import org.folio.innreach.domain.entity.AgencyLocationMapping;
 import org.folio.innreach.domain.exception.EntityNotFoundException;
 import org.folio.innreach.domain.service.AgencyMappingService;
 import org.folio.innreach.domain.service.CentralServerConfigurationService;
-import org.folio.innreach.dto.AgencyLocationAcMappingDTO;
 import org.folio.innreach.dto.AgencyLocationLscMappingDTO;
 import org.folio.innreach.dto.AgencyLocationMappingDTO;
 import org.folio.innreach.dto.LocalServer;

--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -2,12 +2,13 @@ package org.folio.innreach.domain.service.impl;
 
 import static org.folio.innreach.domain.service.impl.ServiceUtils.merge;
 
-import java.util.Collection;	import java.util.*;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
+import java.util.Objects;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;

--- a/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImpl.java
@@ -2,12 +2,7 @@ package org.folio.innreach.domain.service.impl;
 
 import static org.folio.innreach.domain.service.impl.ServiceUtils.merge;
 
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 
 import lombok.RequiredArgsConstructor;
@@ -108,42 +103,21 @@ public class AgencyMappingServiceImpl implements AgencyMappingService {
   private Optional<UUID> getLocationIdByAgencyCode(AgencyLocationMappingDTO mapping, String agencyCode) {
     log.info("getLocationIdByAgencyCode:: Start - parameters mapping: {}, agencyCode: {}", mapping, agencyCode);
 
-    Optional<UUID> locationId = mapping.getLocalServers().stream()
-      .filter(Objects::nonNull)
-      .map(server -> {
-        if (server.getAgencyCodeMappings() == null || server.getAgencyCodeMappings().isEmpty()) {
-          log.warn("getLocationIdByAgencyCode:: agencyCodeMappings is null for server: {}. Skipping this server.", server);
-          return null;
-        }
-        log.info("getLocationIdByAgencyCode:: Processing agencyCodeMappings for server: {}", server);
-        return server.getAgencyCodeMappings();
-      })
-      .filter(Objects::nonNull)
+    return mapping.getLocalServers().stream()
+      .map(AgencyLocationLscMappingDTO::getAgencyCodeMappings)
       .flatMap(Collection::stream)
-      .filter(mappingEntry -> {
-        if (mappingEntry == null) {
-          log.warn("getLocationIdByAgencyCode:: Found null mapping entry. Skipping.");
-          return false;
-        }
-        boolean match = agencyCode != null && agencyCode.equals(mappingEntry.getAgencyCode());
-        if (match) {
-          log.info("getLocationIdByAgencyCode:: Match found for agencyCode: {} with mapping: {}", agencyCode, mappingEntry);
-        }
-        return match;
-      })
+      .filter(m -> agencyCode.equals(m.getAgencyCode()))
       .map(mappingEntry -> {
-        if (mappingEntry.getLocationId() == null) {
+        UUID locationId = mappingEntry.getLocationId();
+        if (locationId == null) {
           log.warn("getLocationIdByAgencyCode:: locationId is null in mapping: {}", mappingEntry);
-          return null;
         }
-        return mappingEntry.getLocationId();
+        return locationId;
       })
       .filter(Objects::nonNull)
       .findFirst();
-
-    log.info("getLocationIdByAgencyCode:: End - returning: {}", locationId);
-    return locationId;
   }
+
 
   private Optional<AgencyLocationMapping> fetchOne(UUID centralServerId) {
     log.debug("fetchOne:: parameters centralServerId: {}", centralServerId);

--- a/src/test/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/AgencyMappingServiceImplTest.java
@@ -1,5 +1,6 @@
 package org.folio.innreach.domain.service.impl;
 
+import static org.folio.innreach.fixture.AgencyLocationMappingFixture.deserializeMapping2;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -61,6 +62,7 @@ class AgencyMappingServiceImplTest {
     assertEquals(AGENCY_LOCATION_ID, locationId);
   }
 
+
   @Test
   void getLocationIdByAgencyCode_usingLocalCodeMapping() {
     var mappingDto = deserializeMapping();
@@ -77,6 +79,24 @@ class AgencyMappingServiceImplTest {
     assertNotNull(locationId);
     assertEquals(LOCAL_SERVER_LOCATION_ID, locationId);
   }
+
+  @Test
+  void getLocationIdByAgencyCode_usingNullLocationId() {
+    var mappingDto = deserializeMapping2();
+    var mapping = mapper.toEntity(mappingDto);
+
+    var unmappedAgency = new Agency().agencyCode(UNMAPPED_AGENCY_CODE);
+    var localServer = new LocalServer().localCode(MAPPED_LOCAL_CODE).addAgencyListItem(unmappedAgency);
+
+    when(repository.fetchOneByCsId(any())).thenReturn(Optional.of(mapping));
+    when(configurationService.getLocalServers(any())).thenReturn(List.of(localServer));
+
+    var locationId = service.getLocationIdByAgencyCode(UUID.randomUUID(), UNMAPPED_AGENCY_CODE);
+
+    assertNotNull(locationId);
+    assertEquals(LOCAL_SERVER_LOCATION_ID, locationId);
+  }
+
 
   @Test
   void getLocationIdByAgencyCode_usingDefaultMapping() {

--- a/src/test/java/org/folio/innreach/fixture/AgencyLocationMappingFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/AgencyLocationMappingFixture.java
@@ -87,4 +87,9 @@ public class AgencyLocationMappingFixture {
       "/agency-mapping/create-agency-mappings-request.json", AgencyLocationMappingDTO.class);
   }
 
+  public static AgencyLocationMappingDTO deserializeMapping2() {
+    return deserializeFromJsonFile(
+      "/agency-mapping/create-agency-mappings-request2.json", AgencyLocationMappingDTO.class);
+  }
+
 }

--- a/src/test/resources/json/agency-mapping/create-agency-mappings-request2.json
+++ b/src/test/resources/json/agency-mapping/create-agency-mappings-request2.json
@@ -1,0 +1,21 @@
+{
+  "libraryId": "1a551e37-af8a-40f5-b25e-0837db791429",
+  "locationId": "ab6a8c69-ee1a-4b52-a881-dc86da6be857",
+  "localServers": [
+    {
+      "localCode": "5htxv",
+      "libraryId": "86dc48c5-9bea-4006-bb43-82f250089651",
+      "locationId": "edb00dae-2735-4e38-bd41-69427295fdbe",
+      "agencyCodeMappings": [
+        {
+          "agencyCode": "abcd1"
+        },
+        {
+          "agencyCode": "5zxcv",
+          "libraryId": "22dcf77c-08ef-43ac-a254-4d3f996a0de9",
+          "locationId": "8c0f7109-2f56-41ab-b2fd-7e326a9323dc"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
To handle NPE when the code is trying to determine the locationId for a particular agency code.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->

## Approach
Handled the null case as described in the top section. The return would be null and further the execution of the code will proceed to determined the locationId for creating the holding and then a virtual item.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
- [ ] Check logging

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
