### PR TITLE
MODINREACH-476 - Remove the RetryTemplate code.

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionServiceImpl.java
@@ -137,13 +137,6 @@ public class ContributionServiceImpl implements ContributionService {
     var iterationJobResponse = triggerInstanceIteration();
     var numberOfRecords = iterationJobResponse.getNumberOfRecordsPublished();
     log.info("numberOfRecords from iterationJobResponse: {}",numberOfRecords);
-
-    JobResponse updatedJobResponse = retryTemplate.execute(r -> getJobResponse(iterationJobResponse.getId()));
-
-    if(updatedJobResponse!=null) {
-      numberOfRecords = updatedJobResponse.getNumberOfRecordsPublished();
-      log.info("numberOfRecords from updatedJobResponse for centralServerId {} is {}", centralServerId, numberOfRecords);
-    }
     contribution.setJobId(iterationJobResponse.getId());
     contribution.setRecordsTotal(numberOfRecords.longValue());
     repository.save(contribution);
@@ -157,27 +150,6 @@ public class ContributionServiceImpl implements ContributionService {
     repository.updateStatisticsByCentralServerId().ifPresent(contribution ->
       log.info("updateStatisticsAndContributionStatus:: recordsTotal - {}, recordsProcessed - {}, recordsContributed - {}",
         contribution.getRecordsTotal(), contribution.getRecordsProcessed(), contribution.getRecordsContributed()));
-  }
-
-  private JobResponse getJobResponse(UUID id) {
-
-    JobResponse responseAfterTrigger = instanceStorageClient.getJobById(id);
-
-    if (responseAfterTrigger != null) {
-      log.info("responseAfterTrigger: status: {}", responseAfterTrigger.getStatus().toString());
-      log.info("responseAfterTrigger: number: {}", responseAfterTrigger.getNumberOfRecordsPublished());
-      log.info("responseAfterTrigger: id: {}", responseAfterTrigger.getId());
-      if (!COMPLETED.equalsIgnoreCase(responseAfterTrigger.getStatus().toString())) {
-        log.info("responseAfterTrigger: not completed yet");
-        throw new InnReachException("Record is still not there " + responseAfterTrigger.getNumberOfRecordsPublished());
-      }
-    }
-    else {
-      log.info("responseAfterTrigger: is null");
-      throw new InnReachException("responseAfterTrigger is null");
-    }
-
-    return responseAfterTrigger;
   }
 
   @Override

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
@@ -100,16 +100,10 @@ class ContributionServiceImplTest {
     verify(repository).save(any(Contribution.class));
 
     when(storageClient.getJobById(any())).thenReturn(null);
-    assertThatThrownBy(() -> service.startInitialContribution(UUID.randomUUID()))
-      .isInstanceOf(InnReachException.class)
-      .hasMessageContaining("responseAfterTrigger is null");
 
     var jobResponse = createJobResponse();
     jobResponse.setNumberOfRecordsPublished(0);
     when(storageClient.getJobById(any())).thenReturn(jobResponse);
-    assertThatThrownBy(() -> service.startInitialContribution(UUID.randomUUID()))
-      .isInstanceOf(InnReachException.class)
-      .hasMessageContaining("Record is still not there");
   }
 
   @Test

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
@@ -118,7 +118,6 @@ class ContributionServiceImplTest {
 
     assertEquals(contribution.getId(), updated.getId());
     assertEquals(COMPLETE, updated.getStatus());
-
   }
 
   @Test

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
@@ -1,6 +1,5 @@
 package org.folio.innreach.domain.service.impl;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.innreach.fixture.JobResponseFixture.updateJobResponse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -18,7 +17,6 @@ import java.util.Optional;
 import java.util.UUID;
 
 import org.folio.innreach.config.props.ContributionJobProperties;
-import org.folio.innreach.external.exception.InnReachException;
 import org.folio.spring.config.properties.FolioEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionServiceImplTest.java
@@ -118,6 +118,7 @@ class ContributionServiceImplTest {
 
     assertEquals(contribution.getId(), updated.getId());
     assertEquals(COMPLETE, updated.getStatus());
+
   }
 
   @Test


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: MODQM-3 - Implement GET records-editor/marc-records/{id} endpoint

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
To fix the issue reported in https://folio-org.atlassian.net/browse/MODINREACH-476
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to update the schema." and
  instead provide an explanation like "there is more data to be provided and stored for Purchase Orders 
  which is currently missing in the schema"

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/MODQM-3
 -->

## Approach
The cause of the bug is [this code](https://github.com/folio-org/mod-inn-reach/blob/master/src/main/java/org/folio/innreach/domain/service/impl/ContributionServiceImpl.java#L141-L149) in mod-inn-reach. The RetryTemplate will block and retry until the job is COMPLETE. It is likely that this code was added to log the job progress. That is no longer necessary. The operator can check on the status of the job through the UI.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->
- [ ] Check logging

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [ ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ ] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
