### PR TITLE
MODINREACH-490: Local server: Enforce UUID of key, explain UUID of secret

### DIFF
--- a/src/main/java/org/folio/innreach/mapper/CentralServerMapper.java
+++ b/src/main/java/org/folio/innreach/mapper/CentralServerMapper.java
@@ -24,8 +24,8 @@ public interface CentralServerMapper {
     }
 
     var localServerCredentials = new LocalServerCredentials();
-    localServerCredentials.setLocalServerKey(centralServerDTO.getLocalServerKey());
-    localServerCredentials.setLocalServerSecret(centralServerDTO.getLocalServerSecret());
+    localServerCredentials.setLocalServerKey(centralServerDTO.getLocalServerKey().toString());
+    localServerCredentials.setLocalServerSecret(centralServerDTO.getLocalServerSecret().toString());
     return localServerCredentials;
   }
 

--- a/src/main/resources/swagger.api/schemas/centralServerDTO.json
+++ b/src/main/resources/swagger.api/schemas/centralServerDTO.json
@@ -51,11 +51,13 @@
     },
     "localServerKey": {
       "description": "Local server key",
-      "type": "string"
+      "type": "string",
+      "format": "UUID"
     },
     "localServerSecret": {
       "description": "Local server secret",
-      "type": "string"
+      "type": "string",
+      "format": "UUID"
     },
     "checkPickupLocation": {
       "description": "Indicates whether to look up pickup locations for INN-Reach item hold requests based on transaction pickupLocation",

--- a/src/test/java/org/folio/innreach/fixture/CentralServerFixture.java
+++ b/src/test/java/org/folio/innreach/fixture/CentralServerFixture.java
@@ -56,8 +56,8 @@ public class CentralServerFixture {
       ))
       .centralServerKey(randomUUIDString())
       .centralServerSecret(randomUUIDString())
-      .localServerKey(randomUUIDString())
-      .localServerSecret(randomUUIDString());
+      .localServerKey(UUID.randomUUID())
+      .localServerSecret(UUID.randomUUID());
   }
 
   public static CentralServerConnectionDetailsDTO createCentralServerConnectionDetailsDTO() {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINREACH-490

## Purpose

POST /inn-reach/authentication requires that key and secret of the local server are UUIDs:

https://github.com/folio-org/mod-inn-reach/blob/v3.4.0/src/main/resources/swagger.api/schemas/authenticationRequest.json#L5-L14 :
```
    "key": {
      "description": "key",
      "type": "string",
      "format": "UUID"
    },
    "secret": {
      "description": "secret",
      "type": "string",
      "format": "UUID"
    }
```


However, when setting these values POST /inn-reach/central-servers and PUT /inn-reach/central-servers/{id} allow any string, and the API documentation doesn't mention the UUID requirement:

https://github.com/folio-org/mod-inn-reach/blob/v3.4.0/src/main/resources/swagger.api/schemas/centralServerDTO.json#L52-L59 : 
```
    "localServerKey": {
      "description": "Local server key",
      "type": "string"
    },
    "localServerSecret": {
      "description": "Local server secret",
      "type": "string"
    },
```

ui-inn-reach sets the values to UUIDs: https://github.com/folio-org/ui-inn-reach/blob/v6.0.0/src/settings/components/CentralServersConfiguration/CentralServersConfigurationForm/CentralServersConfigurationForm.js#L81-L82

## Approach
Change swagger API specs to show this requirement in the API documenation and to enforce it when setting the values.

#### TODOS and Open Questions
- [x] Check logging

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] Were there any schema changes? Yes, but using a non-UUID value has always been failing in the POST /inn-reach/authentication API.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact? None.