### PR TITLE
MODINREACH-495: Could not open JPA EntityManager - use @DirtiesContext

### DIFF
--- a/src/test/java/org/folio/innreach/domain/listener/base/BaseKafkaApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/base/BaseKafkaApiTest.java
@@ -38,6 +38,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
@@ -51,6 +52,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
   INVENTORY_ITEM_TOPIC, INVENTORY_HOLDING_TOPIC, INVENTORY_INSTANCE_TOPIC, INVENTORY_ITEM_TOPIC1, INVENTORY_ITEM_TOPIC2, INVENTORY_ITEM_TOPIC4})
 @SpringBootTest(
   classes = {ModInnReachApplication.class, TestTenantScopedExecutionService.class})
+@DirtiesContext
 @Testcontainers
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public class BaseKafkaApiTest {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINREACH-495

## Purpose
Build fails in about 90 % of all runs with these errors:
```
[ERROR]   KafkaInventoryEventListenerApiTest.shouldReceiveInventoryHoldingEvent » CannotCreateTransaction Could not open JPA EntityManager for transaction
[ERROR]   KafkaInventoryEventListenerApiTest.shouldReceiveInventoryInstanceEvent » CannotCreateTransaction Could not open JPA EntityManager for transaction
[ERROR]   KafkaInventoryEventListenerApiTest.shouldReceiveInventoryItemEvent » CannotCreateTransaction Could not open JPA EntityManager for transaction
[ERROR]   KafkaInventoryEventListenerApiTest.testKafkaListenerListeningInnReachTopics » CannotCreateTransaction Could not open JPA EntityManager for transaction
```

The JDBC related log entries show the cause:
```
10:20:11 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:45835/db?loggerLevel=OFF)
10:20:17 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:42085/db?loggerLevel=OFF)
10:20:22 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:39339/db?loggerLevel=OFF)
10:20:32 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:44855/test?loggerLevel=OFF)
10:21:15 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:45443/test?loggerLevel=OFF)
10:21:48 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:45793/test?loggerLevel=OFF)
Caused by: org.postgresql.util.PSQLException: Connection to localhost:44855 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
Caused by: org.postgresql.util.PSQLException: Connection to localhost:44855 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
10:25:52 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:34307/test?loggerLevel=OFF)
10:26:08 [] [] [] [] INFO  dbcDatabaseContainer Container is started (JDBC URL: jdbc:postgresql://localhost:45933/test?loggerLevel=OFF)
Caused by: org.postgresql.util.PSQLException: Connection to localhost:44855 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
Caused by: org.postgresql.util.PSQLException: Connection to localhost:44855 refused. Check that the hostname and port are correct and that the postmaster is accepting TCP/IP connections.
```

## Approach
Add missing `@DirtiesContext` annotation.

#### TODOS and Open Questions
- [x] Check logging

## Learning
Quote from https://docs.spring.io/spring-framework/reference/6.2/testing/testcontext-framework/ctx-management/dynamic-property-sources.html :

> If you use `@DynamicPropertySource` in a base class and discover that tests in subclasses fail because the dynamic properties change between subclasses, you may need to annotate your base class with `@DirtiesContext` to ensure that each subclass gets its own ApplicationContext with the correct dynamic properties.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.