### PR TITLE
MODINREACH-467: Assign Item Hold Transaction due date when item checked out to the borrowing site

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,11 @@
-## v3.X.X 2025-xx-xx
+## v3.5.0 2025-xx-xx
 
 ### Bugs
 * [MODINREACH-503](https://folio-org.atlassian.net/browse/MODINREACH-503) - [INN-Reach] Add missing tokens to API
+* [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Recontribute for requested Item on automatically item hold cancelled transaction.
+* [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Bump Spring Boot from 3.4.4 to 3.5.0
+* [MODINREACH-496](https://folio-org.atlassian.net/browse/MODINREACH-496) - Add missing module permission to get holdings sources for INN-Reach circulation endpoints
+* [MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467) - Assign Item Hold Transaction due date when item checked out to borrowing site
 
 ## v3.4.1 2025-04-15
 
@@ -9,9 +13,6 @@
 * [MODINREACH-487](https://folio-org.atlassian.net/browse/MODINREACH-487) - fixed HTTP 414 (URI too long) error for INN-Reach Paging Slips
 * [MODINREACH-488](https://folio-org.atlassian.net/browse/MODINREACH-488) - Bump Spring Boot from 3.4.3 to 3.4.4
 * [MODINREACH-490](https://folio-org.atlassian.net/browse/MODINREACH-490) - Local server: Enforce UUID of key, explain UUID of secret
-* [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Recontribute for requested Item on automatically item hold cancelled transaction.
-* [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Bump Spring Boot from 3.4.4 to 3.5.0
-* [MODINREACH-496](https://folio-org.atlassian.net/browse/MODINREACH-496) - Add missing module permission to get holdings sources for INN-Reach circulation endpoints
 
 ## v3.4.0 2025-03-14
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -161,6 +161,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     var callNumber = checkOutResponse.getItem().getCallNumber();
 
     hold.setFolioLoanId(checkOutResponse.getId());
+    hold.setDueDateTime(toEpochSec(checkOutResponse.getDueDate()));
 
     transaction.setState(ITEM_SHIPPED);
 

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -1429,7 +1429,8 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
 
     var checkOutResponse = new LoanDTO()
       .id(FOLIO_CHECKOUT_ID)
-      .item(new LoanItem().barcode(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE));
+      .item(new LoanItem().barcode(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE))
+      .dueDate(Date.from(DUE_DATE.toInstant()));
 
     when(circulationClient.checkOutByBarcode(any(CheckOutRequestDTO.class))).thenReturn(checkOutResponse);
 

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -1,5 +1,6 @@
 package org.folio.innreach.controller;
 
+import static java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 import static java.util.UUID.randomUUID;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -58,6 +59,7 @@ import static org.folio.innreach.fixture.UserFixture.createUser;
 import static org.folio.innreach.util.DateHelper.toEpochSec;
 
 import java.time.Duration;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -203,6 +205,10 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
   private static final AuditableUser PRE_POPULATED_USER = AuditableUser.SYSTEM;
 
   private static final Duration ASYNC_AWAIT_TIMEOUT = Duration.ofSeconds(15);
+
+  private static final OffsetDateTime DUE_DATE = OffsetDateTime.parse(
+    "2025-07-30T05:00:00+02:00",
+    ISO_OFFSET_DATE_TIME);
 
   @Autowired
   private TestRestTemplate testRestTemplate;
@@ -1364,9 +1370,11 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
   })
   void testCheckOutItemHoldItem() {
+    var expectedDueDate = Date.from(DUE_DATE.toInstant());
     var checkOutResponse = new LoanDTO()
       .id(FOLIO_CHECKOUT_ID)
-      .item(new LoanItem().barcode(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE));
+      .item(new LoanItem().barcode(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE))
+        .dueDate(expectedDueDate);
 
     when(circulationClient.checkOutByBarcode(any(CheckOutRequestDTO.class))).thenReturn(checkOutResponse);
 
@@ -1381,10 +1389,12 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
 
     var transaction = response.getTransaction();
     assertEquals(PRE_POPULATED_ITEM_HOLD_TRANSACTION_ID, transaction.getId());
+    assertEquals(toEpochSec(expectedDueDate), transaction.getHold().getDueDateTime());
 
     var folioCheckOut = response.getFolioCheckOut();
     assertNotNull(folioCheckOut);
     assertEquals(FOLIO_CHECKOUT_ID, folioCheckOut.getId());
+    assertEquals(expectedDueDate, folioCheckOut.getDueDate());
   }
 
   @Test


### PR DESCRIPTION
### Purpose
Due date time is missing for Item Transaction Holds.

### Approach
- when item is checked out to the borrowing site and check-out loan is created take the loan due date and assign it to transaction hold's due date attribute

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467)