### PR TITLE
MODINREACH-508: Add missing permissions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Bump Spring Boot from 3.4.4 to 3.5.0
 * [MODINREACH-496](https://folio-org.atlassian.net/browse/MODINREACH-496) - Add missing module permission to get holdings sources for INN-Reach circulation endpoints
 * [MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467) - Assign Item Hold Transaction due date when item checked out to borrowing site
+* [MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508) - Add missing permissions for INN-Reach circulation endpoints and for System User
 
 ## v3.4.1 2025-04-15
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -396,7 +396,11 @@
             "circulation.loans.claim-item-returned.post",
             "inventory.instances.item.get",
             "users.collection.get",
-            "configuration.entries.collection.get"
+            "configuration.entries.collection.get",
+            "inventory.items.item.delete",
+            "inventory-storage.holdings.item.delete",
+            "inventory.instances.item.delete",
+            "circulation.loans.item.delete"
           ]
         },
         {
@@ -472,7 +476,12 @@
           "modulePermissions": [
             "inventory.items.item.get",
             "circulation.requests.item.get",
-            "circulation.requests.item.put"
+            "circulation.requests.item.put",
+            "circulation.requests.item.delete",
+            "circulation.loans.item.delete",
+            "inventory.items.item.delete",
+            "inventory-storage.holdings.item.delete",
+            "inventory.instances.item.delete"
           ]
         },
         {
@@ -1365,7 +1374,12 @@
         "circulation.requests.collection.get",
         "circulation.loans.collection.get",
         "inventory.items.item.put",
-        "inventory-storage.holdings.item.put"
+        "inventory-storage.holdings.item.put",
+        "circulation.requests.item.delete",
+        "circulation.loans.item.delete",
+        "inventory.items.item.delete",
+        "inventory-storage.holdings.item.delete",
+        "inventory.instances.item.delete"
       ]
     }
   },

--- a/src/main/java/org/folio/innreach/domain/listener/KafkaCirculationEventListener.java
+++ b/src/main/java/org/folio/innreach/domain/listener/KafkaCirculationEventListener.java
@@ -5,7 +5,6 @@ import static org.folio.innreach.domain.event.DomainEventType.UPDATED;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -106,7 +105,7 @@ public class KafkaCirculationEventListener {
     return consumerRecords.stream()
       .map(ConsumerRecord::value)
       .filter(Objects::nonNull)
-      .collect(Collectors.toList());
+      .toList();
   }
 
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -301,10 +301,10 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     var request = requestService.findRequest(requestId);
 
     if (requestService.isOpenRequest(request)) {
-      log.info("cancelPatronHold:: is request open");
+      log.info("cancelPatronHold:: request is open");
       cancelPatronHoldWithOpenRequest(cancelRequest, transaction);
     } else if (request.getStatus() == CLOSED_CANCELLED) {
-      log.info("cancelPatronHold:: is request closed cancelled");
+      log.info("cancelPatronHold:: request is closed cancelled");
       cancelPatronHoldWithClosedRequest(transaction);
     }
 

--- a/src/main/resources/permissions/mod-innreach.csv
+++ b/src/main/resources/permissions/mod-innreach.csv
@@ -16,3 +16,8 @@ circulation.requests.collection.get
 circulation.loans.collection.get
 inventory.items.item.put
 inventory-storage.holdings.item.put
+circulation.requests.item.delete
+circulation.loans.item.delete
+inventory.items.item.delete
+inventory-storage.holdings.item.delete
+inventory.instances.item.delete


### PR DESCRIPTION
### Purpose
Some of the System User and module permissions are missing, namely for `PUT /d2ir/circ/finalcheckin/{trackingId}/{centralCode}`, `PUT /d2ir/circ/cancelrequest/{trackingId}/{centralCode}`, `POST /transactions/{id}/patronhold/cancel` and handling the circulation request update event

### Approach
add missing permissions into respective module permissions for the APIs and for the system user

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508)
