### PR TITLE
MODINREACH-482: Add remove patron hold transaction api

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * [MODINREACH-496](https://folio-org.atlassian.net/browse/MODINREACH-496) - Add missing module permission to get holdings sources for INN-Reach circulation endpoints
 * [MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467) - Assign Item Hold Transaction due date when item checked out to borrowing site
 * [MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508) - Add missing permissions for INN-Reach circulation endpoints and for System User
+* [MODINREACH-482](https://folio-org.atlassian.net/browse/MODINREACH-482) - Add remove patron hold API to cancel `PATRON_HOLD` transactions with no created virtual item and request
 
 ## v3.4.1 2025-04-15
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -58,7 +58,7 @@
   "provides": [
     {
       "id": "inn-reach",
-      "version": "1.1",
+      "version": "1.2",
       "handlers": [
         {
           "methods": ["POST"],
@@ -482,6 +482,15 @@
             "inventory.items.item.delete",
             "inventory-storage.holdings.item.delete",
             "inventory.instances.item.delete"
+          ]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/inn-reach/transactions/{id}/patronhold/remove",
+          "permissionsRequired": ["inn-reach.d2ir.inn-reach-transaction.patron-hold.remove.post"],
+          "modulePermissions": [
+            "inventory.items.item.get",
+            "circulation.requests.item.get"
           ]
         },
         {
@@ -1079,6 +1088,11 @@
       "description" : "POST INN-Reach Transaction: Cancel Patron Hold"
     },
     {
+      "permissionName" : "inn-reach.d2ir.inn-reach-transaction.patron-hold.remove.post",
+      "displayName" : "POST INN-Reach Transaction: Remove Patron Hold",
+      "description" : "POST INN-Reach Transaction: Remove Patron Hold"
+    },
+    {
       "permissionName" : "inn-reach.d2ir.inn-reach-transaction.item-hold.cancel.post",
       "displayName" : "POST INN-Reach Transaction: Cancel Item Hold",
       "description" : "POST INN-Reach Transaction: Cancel Item Hold"
@@ -1160,7 +1174,8 @@
         "inn-reach.d2ir.inn-reach-transaction.item-hold.recall.post",
         "inn-reach.d2ir.inn-reach-transaction.patron-hold.return-item.post",
         "inn-reach.d2ir.inn-reach-transaction.item-hold.final-checkin.post",
-        "inn-reach.inn-reach-transaction.item.get"
+        "inn-reach.inn-reach-transaction.item.get",
+        "inn-reach.d2ir.inn-reach-transaction.patron-hold.remove.post"
       ]
     },
     {

--- a/src/main/java/org/folio/innreach/controller/InnReachTransactionController.java
+++ b/src/main/java/org/folio/innreach/controller/InnReachTransactionController.java
@@ -2,8 +2,6 @@ package org.folio.innreach.controller;
 
 import java.util.UUID;
 
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -109,7 +107,8 @@ public class InnReachTransactionController implements InnReachTransactionApi {
   @Override
   @PostMapping("/{id}/patronhold/remove")
   public ResponseEntity<InnReachTransactionDTO> removePatronHoldTransaction(@PathVariable("id") UUID id) {
-
+    var response = transactionActionService.removePatronHold(id);
+    return ResponseEntity.ok(response);
   }
 
   @Override

--- a/src/main/java/org/folio/innreach/controller/InnReachTransactionController.java
+++ b/src/main/java/org/folio/innreach/controller/InnReachTransactionController.java
@@ -2,6 +2,8 @@ package org.folio.innreach.controller;
 
 import java.util.UUID;
 
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -102,6 +104,12 @@ public class InnReachTransactionController implements InnReachTransactionApi {
 
     var response = transactionActionService.cancelPatronHold(id, cancelRequest);
     return ResponseEntity.ok(response);
+  }
+
+  @Override
+  @PostMapping("/{id}/patronhold/remove")
+  public ResponseEntity<InnReachTransactionDTO> removePatronHoldTransaction(@PathVariable("id") UUID id) {
+
   }
 
   @Override

--- a/src/main/java/org/folio/innreach/domain/service/InnReachTransactionActionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/InnReachTransactionActionService.java
@@ -35,6 +35,8 @@ public interface InnReachTransactionActionService {
 
   InnReachTransactionDTO cancelPatronHold(UUID transactionId, CancelTransactionHoldDTO cancelRequest);
 
+  InnReachTransactionDTO removePatronHold(UUID transactionId);
+
   void recallItemHold(UUID transactionId);
 
   void cancelItemHold(UUID transactionId, CancelTransactionHoldDTO cancelRequest);

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -46,6 +46,7 @@ import org.folio.innreach.domain.entity.TransactionPatronHold;
 import org.folio.innreach.domain.event.CancelRequestEvent;
 import org.folio.innreach.domain.event.MoveRequestEvent;
 import org.folio.innreach.domain.event.RecallRequestEvent;
+import org.folio.innreach.domain.exception.CirculationException;
 import org.folio.innreach.domain.exception.EntityNotFoundException;
 import org.folio.innreach.domain.service.InnReachRecallUserService;
 import org.folio.innreach.domain.service.InnReachTransactionActionService;
@@ -309,6 +310,30 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     }
 
     log.info("Patron request successfully cancelled");
+    return transactionMapper.toDTO(transaction);
+  }
+
+  @Override
+  public InnReachTransactionDTO removePatronHold(UUID transactionId) {
+    log.info("Removing Patron Hold transaction: {}", transactionId);
+
+    var transaction = fetchTransactionOfType(transactionId, PATRON);
+    verifyState(transaction, PATRON_HOLD);
+
+    var requestId = transaction.getHold().getFolioRequestId();
+    var itemId = transaction.getHold().getFolioItemId();
+
+    if (itemId != null && requestId != null && itemService.find(itemId).isPresent()
+      && requestService.findRequest(requestId) != null) {
+      log.warn("removePatronHold:: illegal operation to remove PATRON_HOLD transaction, item and request are present");
+      throw new CirculationException("Removing valid PATRON_HOLD transaction is not allowed, " +
+        "item: %s and request: %s are present".formatted(itemId, requestId));
+    }
+
+    transaction.setState(CANCEL_REQUEST);
+    transactionRepository.save(transaction);
+
+    log.info("Patron request successfully removed");
     return transactionMapper.toDTO(transaction);
   }
 

--- a/src/main/resources/swagger.api/circulation.yaml
+++ b/src/main/resources/swagger.api/circulation.yaml
@@ -313,6 +313,25 @@ paths:
           $ref: "api-common.yaml#/components/responses/trait_response_500"
       parameters:
         - $ref: 'api-common.yaml#/components/parameters/id'
+  /transactions/{id}/patronhold/remove:
+    post:
+      operationId: removePatronHoldTransaction
+      description: Cancel patron hold transaction which does not have associated item and request details
+      tags:
+        - inn-reach-transaction
+      responses:
+        '200':
+          description: "OK"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/innReachTransactionDTO"
+        '404':
+          $ref: "api-common.yaml#/components/responses/trait_response_404"
+        '500':
+          $ref: "api-common.yaml#/components/responses/trait_response_500"
+      parameters:
+        - $ref: 'api-common.yaml#/components/parameters/id'
   /transactions/{id}/itemhold/recall:
     post:
       operationId: recallItemHoldTransaction

--- a/src/test/resources/db/inn-reach-transaction/pre-populate-inn-reach-broken_patron_hold_transaction.sql
+++ b/src/test/resources/db/inn-reach-transaction/pre-populate-inn-reach-broken_patron_hold_transaction.sql
@@ -1,0 +1,15 @@
+INSERT INTO transaction_pickup_location (id, pickup_loc_code, print_name, delivery_stop) VALUES
+('809adcde-3e67-4822-9916-fd653a681358', 'pickupLocCode1', 'printName1', 'deliveryStop1');
+
+INSERT INTO transaction_hold (id, transaction_time, pickup_location_id, patron_id, patron_agency_code, item_agency_code, item_id,
+central_item_type, need_before, title, author, folio_patron_id, folio_item_id, due_date_time, folio_request_id, folio_loan_id,
+folio_item_barcode, folio_patron_barcode, folio_instance_id, folio_holding_id, central_patron_type, patron_name) VALUES
+('76834d5a-08e8-45ea-84ca-4d9b10aa340c', extract(epoch from current_timestamp), '809adcde-3e67-4822-9916-fd653a681358',
+ 'ifkkmbcnljgy5elaav74pnxgxa', 'qwe12', 'asd34', 'item1', 1, extract(epoch from current_timestamp), 'title1', 'author1',
+ '4154a604-4d5a-4d8e-9160-057fc7b6e6b8', null, null, null, null, null, '000001', null, null, 2, 'patronName1');
+
+INSERT INTO transaction_patron_hold (id) VALUES
+('76834d5a-08e8-45ea-84ca-4d9b10aa340c');
+
+INSERT INTO inn_reach_transaction (id, tracking_id, central_server_code, state, type, transaction_hold_id) VALUES
+('0aab1720-14b4-4210-9a19-0d0bf1cd64d3', 'tracking1', 'd2ir', 1, 1, '76834d5a-08e8-45ea-84ca-4d9b10aa340c');


### PR DESCRIPTION
### Purpose
add possibility to mark invalid `PATRON_HOLD` transactions without created virtual item and item request as cancelled

### Approach
- add new api description and it's implementation
- add test
- bump minor version of `inn-reach` 

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [x] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-482](https://folio-org.atlassian.net/browse/MODINREACH-482)
