### PR TITLE
MODINREACH-524: Fix handling OWNER_RENEW message from INN-REACH central

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * [MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467) - Assign Item Hold Transaction due date when item checked out to borrowing site
 * [MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508) - Add missing permissions for INN-Reach circulation endpoints and for System User
 * [MODINREACH-482](https://folio-org.atlassian.net/browse/MODINREACH-482) - Add remove patron hold API to cancel `PATRON_HOLD` transactions with no created virtual item and request
+* [MODINREACH-524](https://folio-org.atlassian.net/browse/MODINREACH-524) - Fix handling Owner Renew Item message (Borrowing Site) and setting correct state
 
 ## v3.4.1 2025-04-15
 

--- a/src/main/java/org/folio/innreach/controller/d2ir/InnReachCirculationController.java
+++ b/src/main/java/org/folio/innreach/controller/d2ir/InnReachCirculationController.java
@@ -1,6 +1,7 @@
 package org.folio.innreach.controller.d2ir;
 
 import lombok.RequiredArgsConstructor;
+import org.folio.innreach.domain.service.InnReachTransactionService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -35,6 +36,7 @@ public class InnReachCirculationController implements InnReachCirculationApi {
 
   private final CirculationService circulationService;
   private final RequestService requestService;
+  private final InnReachTransactionService innReachTransactionService;
 
   @Override
   @PostMapping("/itemhold/{trackingId}/{centralCode}")
@@ -191,6 +193,7 @@ public class InnReachCirculationController implements InnReachCirculationApi {
       produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<InnReachResponseDTO> ownerRenew(@PathVariable String trackingId,
                                                         @PathVariable String centralCode, RenewLoanDTO renewLoan) {
+    innReachTransactionService.updateInnReachTransactionOnOwnerRenew(trackingId, centralCode, renewLoan.getDueDateTime());
     var innReachResponse = circulationService.ownerRenewLoan(trackingId, centralCode, renewLoan);
 
     return ResponseEntity.ok(innReachResponse);

--- a/src/main/java/org/folio/innreach/domain/service/InnReachTransactionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/InnReachTransactionService.java
@@ -16,4 +16,6 @@ public interface InnReachTransactionService {
   InnReachTransactionsDTO getAllTransactions(Integer offset, Integer limit, InnReachTransactionFilterParametersDTO parameters);
 
   void updateInnReachTransaction(UUID transactionId, InnReachTransactionDTO transaction);
+
+  void updateInnReachTransactionOnOwnerRenew(String trackingId, String centralCode, Integer dueDate);
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -437,15 +437,11 @@ public class CirculationServiceImpl implements CirculationService {
     patronInfoService.populateTransactionPatronInfo(transaction.getHold(), centralCode);
 
     var renewedLoan = renewLoan(transaction.getHold());
-
     var calculatedDueDate = renewedLoan.getDueDate().toInstant();
     var requestedDueDate = ofEpochSecond(renewLoan.getDueDateTime());
     if (calculatedDueDate.isAfter(requestedDueDate)) {
       loanService.changeDueDate(renewedLoan, Date.from(requestedDueDate));
     }
-
-    transaction.getHold().setDueDateTime(renewLoan.getDueDateTime());
-    transaction.setState(OWNER_RENEW);
 
     log.info("ownerRenewLoan:: result: {}", success());
     return success();

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -15,6 +15,7 @@ import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionSt
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_SHIPPED;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.LOCAL_CHECKOUT;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.LOCAL_HOLD;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.OWNER_RENEW;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.PATRON_HOLD;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECALL;
 import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
@@ -551,6 +552,13 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
   private void updateTransactionOnLoanRenewal(StorageLoanDTO loan, InnReachTransaction transaction) {
     log.debug("updateTransactionOnLoanRenewal:: parameters loan: {}, transaction: {}", loan, transaction);
     if (transaction.getType() != PATRON) {
+      return;
+    }
+
+    if (transaction.getState() == OWNER_RENEW) {
+      // on reacting to OWNER_RENEW message the borrower for patron transaction sets state to OWNER_RENEW and due date
+      // to the requested one which results in updating/renewing the related loan. So, no need to update the transaction
+      // again here by reacting to the resulted renew action.
       return;
     }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionServiceImpl.java
@@ -93,7 +93,7 @@ public class InnReachTransactionServiceImpl implements InnReachTransactionServic
       .orElseThrow(() -> new EntityNotFoundException(format(
         "InnReach transaction with tracking id [%s] and central code [%s] not found", trackingId, centralCode)));
     if (transaction.getType() != PATRON) {
-      throw new IllegalStateException(format(
+      throw new IllegalArgumentException(format(
         "InnReach transaction with tracking id [%s] and central code [%s] is not of type PATRON",
         trackingId, centralCode));
     }

--- a/src/test/java/org/folio/innreach/controller/d2ir/OwnerRenewCirculationApiTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/OwnerRenewCirculationApiTest.java
@@ -27,7 +27,6 @@ import static org.folio.innreach.fixture.TestUtil.randomAlphanumeric5;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.folio.innreach.util.UUIDEncoder;
@@ -66,7 +65,6 @@ class OwnerRenewCirculationApiTest extends BaseApiControllerTest {
   private static final int REQ_DUE_DATE_TIME_BEFORE = (int) Instant.parse("2021-12-01T00:00:00Z").getEpochSecond();
   private static final String LOAN_ID = "19bb9798-d396-4b37-8fd6-5df0885e020e";
   private static final String PRE_POPULATED_PATRON_ID = "ifkkmbcnljgy5elaav74pnxgxa";
-  private static final UUID PRE_POPULATE_PATRON_GROUP_ID = UUID.fromString("8534295a-e031-4738-a952-f7db900df8c0");
 
   @Autowired
   private InnReachTransactionRepository repository;


### PR DESCRIPTION
### Purpose
Inn Reach Transaction state is incorrectly updated to `BORROWER_RENEW` instead of `OWNER_RENEW` on receiving `OWNER_RENEW` message at borrowing site

### Approach
- ignore loan renewed event handling for case of updating loan for `OWNER_RENEW` message handling

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-524](https://folio-org.atlassian.net/browse/MODINREACH-524)