### PR TITLE
MODINREACH-427: Checkout item and notify central Inn-Reach server on Request update and closing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * [MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467) - Assign Item Hold Transaction due date when item checked out to borrowing site
 * [MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508) - Add missing permissions for INN-Reach circulation endpoints and for System User
 * [MODINREACH-482](https://folio-org.atlassian.net/browse/MODINREACH-482) - Add remove patron hold API to cancel `PATRON_HOLD` transactions with no created virtual item and request
+* [MODINREACH-427](https://folio-org.atlassian.net/browse/MODINREACH-427) - checkout local hold item on closing of item request and notify inn-reach central server
 
 ## v3.4.1 2025-04-15
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * [MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508) - Add missing permissions for INN-Reach circulation endpoints and for System User
 * [MODINREACH-482](https://folio-org.atlassian.net/browse/MODINREACH-482) - Add remove patron hold API to cancel `PATRON_HOLD` transactions with no created virtual item and request
 * [MODINREACH-524](https://folio-org.atlassian.net/browse/MODINREACH-524) - Fix handling Owner Renew Item message (Borrowing Site) and setting correct state
-* [MODINREACH-427](https://folio-org.atlassian.net/browse/MODINREACH-427) - checkout local hold item on closing of item request and notify inn-reach central server
+* [MODINREACH-427](https://folio-org.atlassian.net/browse/MODINREACH-427) - Checkout local hold item on closing of item request and notify inn-reach central server
 
 ## v3.4.1 2025-04-15
 

--- a/src/main/java/org/folio/innreach/domain/listener/KafkaCirculationEventListener.java
+++ b/src/main/java/org/folio/innreach/domain/listener/KafkaCirculationEventListener.java
@@ -70,11 +70,12 @@ public class KafkaCirculationEventListener {
 
     eventProcessor.process(events, event -> {
       var newEntity = event.getData().getNewEntity();
+      var oldEntity = event.getData().getOldEntity();
 
       contributionActionService.handleRequestChange(newEntity);
 
       if (event.getType() == UPDATED) {
-        transactionActionService.handleRequestUpdate(newEntity);
+        transactionActionService.handleRequestUpdate(oldEntity, newEntity);
       }
     });
   }

--- a/src/main/java/org/folio/innreach/domain/service/InnReachTransactionActionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/InnReachTransactionActionService.java
@@ -27,7 +27,7 @@ public interface InnReachTransactionActionService {
 
   void handleLoanUpdate(StorageLoanDTO loan);
 
-  void handleRequestUpdate(RequestDTO requestDTO);
+  void handleRequestUpdate(RequestDTO oldRequest, RequestDTO newRequest);
 
   void handleCheckInCreation(CheckInDTO checkIn);
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -104,6 +104,15 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     AWAITING_PICKUP.getValue(), PAGED.getValue(), IN_TRANSIT.getValue(), CHECKED_OUT.getValue()
   };
 
+  private static final List<RequestDTO.RequestStatus> REQUEST_CLOSED_STATUSES_OTHER_THAN_FILLED = List.of(
+    CLOSED_CANCELLED, RequestDTO.RequestStatus.CLOSED_UNFILLED, RequestDTO.RequestStatus.CLOSED_PICKUP_EXPIRED
+  );
+
+  private static final List<RequestDTO.RequestStatus> REQUEST_OPEN_STATUSES = List.of(
+    OPEN_NOT_YET_FILLED, RequestDTO.RequestStatus.OPEN_AWAITING_PICKUP, RequestDTO.RequestStatus.OPEN_IN_TRANSIT,
+    RequestDTO.RequestStatus.OPEN_AWAITING_DELIVERY
+  );
+
   @Override
   public PatronHoldCheckInResponseDTO checkInPatronHoldItem(UUID transactionId, UUID servicePointId) {
     log.debug("checkInPatronHoldItem:: parameters transactionId: {}, servicePointId: {}", transactionId, servicePointId);
@@ -231,19 +240,19 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
   }
 
   @Override
-  public void handleRequestUpdate(RequestDTO requestDTO) {
-    log.debug("handleRequestUpdate:: parameters requestDTO: {}", requestDTO);
-    var transaction = transactionRepository.fetchActiveByRequestId(requestDTO.getId()).orElse(null);
+  public void handleRequestUpdate(RequestDTO oldRequest, RequestDTO newRequest) {
+    log.debug("handleRequestUpdate:: parameters old requestDTO: {}, new requestDTO: {}", oldRequest, newRequest);
+    var transaction = transactionRepository.fetchActiveByRequestId(newRequest.getId()).orElse(null);
     if (transaction == null) {
       return;
     }
 
     if (transaction.getType() == ITEM) {
-      updateItemTransactionOnRequestChange(requestDTO, transaction);
+      updateItemTransactionOnRequestChange(newRequest, transaction);
     } else if (transaction.getType() == PATRON) {
-      updatePatronTransactionOnRequestChange(requestDTO, transaction);
+      updatePatronTransactionOnRequestChange(newRequest, transaction);
     } else if (transaction.getType() == LOCAL) {
-      updateLocalTransactionOnRequestChange(requestDTO, transaction);
+      updateLocalTransactionOnRequestChange(oldRequest, newRequest, transaction);
     }
     log.info("handleRequestUpdate:: Request updated");
   }
@@ -734,20 +743,23 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
   }
 
 
-  private void updateLocalTransactionOnRequestChange(RequestDTO request, InnReachTransaction transaction) {
-    log.debug("updateLocalTransactionOnRequestChange:: parameters request: {}, transaction: {}", request, transaction);
+  private void updateLocalTransactionOnRequestChange(RequestDTO oldRequest, RequestDTO newRequest, InnReachTransaction transaction) {
+    log.debug("updateLocalTransactionOnRequestChange:: parameters request: {}, transaction: {}", newRequest, transaction);
     var hold = transaction.getHold();
     var transactionItemId = hold.getFolioItemId();
-    var itemId = request.getItemId();
+    var itemId = newRequest.getItemId();
     var requestId = hold.getFolioRequestId();
 
-    if (!transactionItemId.equals(itemId)) {
+    if (REQUEST_OPEN_STATUSES.contains(oldRequest.getStatus()) &&
+      REQUEST_CLOSED_STATUSES_OTHER_THAN_FILLED.contains(newRequest.getStatus())) {
+      checkOutItem(transaction, newRequest.getPickupServicePointId());
+    } else if (!transactionItemId.equals(itemId)) {
       log.info("Updating local hold transaction {} on moving a request {} from item {} to {}",
         transaction.getId(), requestId, transactionItemId, itemId);
 
-      var item = fetchItemById(request.getItemId());
+      var item = fetchItemById(newRequest.getItemId());
 
-      updateTransactionOnMovedRequest(request, item, transaction);
+      updateTransactionOnMovedRequest(newRequest, item, transaction);
     }
   }
 

--- a/src/test/java/org/folio/innreach/batch/contribution/service/InnReachTransactionActionServiceTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/InnReachTransactionActionServiceTest.java
@@ -33,7 +33,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
-public class InnReachTransactionActionServiceTest {
+class InnReachTransactionActionServiceTest {
 
   @Mock
   private InnReachTransactionRepository transactionRepository;

--- a/src/test/java/org/folio/innreach/batch/contribution/service/InnReachTransactionActionServiceTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/InnReachTransactionActionServiceTest.java
@@ -1,0 +1,173 @@
+package org.folio.innreach.batch.contribution.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
+import org.folio.innreach.domain.dto.folio.inventory.InventoryItemDTO;
+import org.folio.innreach.domain.entity.InnReachTransaction;
+import org.folio.innreach.domain.entity.TransactionLocalHold;
+import org.folio.innreach.domain.service.InnReachRecallUserService;
+import org.folio.innreach.domain.service.InstanceService;
+import org.folio.innreach.domain.service.ItemService;
+import org.folio.innreach.domain.service.LoanService;
+import org.folio.innreach.domain.service.PatronHoldService;
+import org.folio.innreach.domain.service.RequestService;
+import org.folio.innreach.domain.service.VirtualRecordService;
+import org.folio.innreach.domain.service.impl.InnReachTransactionActionNotifier;
+import org.folio.innreach.domain.service.impl.InnReachTransactionActionServiceImpl;
+import org.folio.innreach.dto.LoanDTO;
+import org.folio.innreach.dto.LoanStatus;
+import org.folio.innreach.dto.StorageLoanDTO;
+import org.folio.innreach.mapper.InnReachTransactionMapper;
+import org.folio.innreach.repository.InnReachTransactionRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+public class InnReachTransactionActionServiceTest {
+
+  @Mock
+  private InnReachTransactionRepository transactionRepository;
+  @Mock
+  private InnReachTransactionMapper transactionMapper;
+  @Mock
+  private RequestService requestService;
+  @Mock
+  private LoanService loanService;
+  @Mock
+  private PatronHoldService patronHoldService;
+  @Mock
+  private ItemService itemService;
+  @Mock
+  private InstanceService instanceService;
+  @Mock
+  private InnReachTransactionActionNotifier notifier;
+  @Mock
+  private ApplicationEventPublisher eventPublisher;
+  @Mock
+  private InnReachRecallUserService recallUserService;
+  @Mock
+  private VirtualRecordService virtualRecordService;
+
+  @InjectMocks
+  private InnReachTransactionActionServiceImpl service;
+
+  @Test
+  void whenItemCheckedOut_onLocalHoldTransaction_shouldSetLocalCheckoutStatusAndNotifyCentral() {
+    // Arrange
+    var loanId = UUID.randomUUID();
+    var itemId = UUID.randomUUID();
+    var patronId = UUID.randomUUID();
+    var dueDate = new Date();
+
+    var loan = createLoanDTO(loanId, itemId, patronId, dueDate);
+    var transaction = createLocalTransaction();
+    var itemDto = InventoryItemDTO.builder().hrid("it0001").barcode("item001").build();
+
+    when(transactionRepository.fetchActiveByFolioItemIdAndPatronId(itemId, patronId))
+      .thenReturn(Optional.of(transaction));
+    when(itemService.find(itemId)).thenReturn(Optional.of(itemDto));
+
+    // Act
+    service.associateNewLoanWithTransaction(loan);
+
+    // Assert
+    assertEquals(InnReachTransaction.TransactionState.LOCAL_CHECKOUT, transaction.getState());
+    verify(transactionRepository).fetchActiveByFolioItemIdAndPatronId(itemId, patronId);
+    verify(notifier).reportCheckOut(transaction, itemDto.getHrid(), itemDto.getBarcode());
+  }
+
+  @Test
+  void whenRequestIsUpdatedAndClosedByOtherMeans_onLocalHoldTransaction_shouldCheckOutItem() {
+    // Arrange
+    var requestId = UUID.randomUUID();
+    var itemId = UUID.randomUUID();
+    var servicePointId = UUID.randomUUID();
+
+    var oldRequest = createRequestDTO(requestId, itemId, RequestDTO.RequestStatus.OPEN_NOT_YET_FILLED, servicePointId);
+    var newRequest = createRequestDTO(requestId, itemId, RequestDTO.RequestStatus.CLOSED_CANCELLED, servicePointId);
+
+    var transaction = createLocalTransaction();
+    transaction.getHold().setFolioRequestId(requestId);
+    transaction.getHold().setFolioItemId(itemId);
+
+    when(transactionRepository.fetchActiveByRequestId(requestId)).thenReturn(Optional.of(transaction));
+    when(loanService.findByItemId(itemId)).thenReturn(Optional.empty());
+
+    // Act
+    service.handleRequestUpdate(oldRequest, newRequest);
+
+    // Assert
+    verify(loanService).checkOutItem(transaction, servicePointId);
+  }
+
+  @Test
+  void whenRequestIsUpdatedAndClosedByOtherMeans_onLocalHoldTransactionWithOpenLoan_shouldUpdateStatusAndNotifyCentral() {
+    // Arrange
+    var requestId = UUID.randomUUID();
+    var itemId = UUID.randomUUID();
+    var servicePointId = UUID.randomUUID();
+
+    var oldRequest = createRequestDTO(requestId, itemId, RequestDTO.RequestStatus.OPEN_NOT_YET_FILLED, servicePointId);
+    var newRequest = createRequestDTO(requestId, itemId, RequestDTO.RequestStatus.CLOSED_CANCELLED, servicePointId);
+    var itemDto = InventoryItemDTO.builder().hrid("it0001").barcode("item001").build();
+    var loanDto = new LoanDTO();
+    loanDto.setStatus(new LoanStatus());
+
+    var transaction = createLocalTransaction();
+    transaction.getHold().setFolioRequestId(requestId);
+    transaction.getHold().setFolioItemId(itemId);
+
+    when(transactionRepository.fetchActiveByRequestId(requestId)).thenReturn(Optional.of(transaction));
+    when(loanService.findByItemId(itemId)).thenReturn(Optional.of(loanDto));
+    when(itemService.find(itemId)).thenReturn(Optional.of(itemDto));
+    when(loanService.isOpen(loanDto)).thenReturn(true);
+
+    // Act
+    service.handleRequestUpdate(oldRequest, newRequest);
+
+    // Assert
+    assertEquals(InnReachTransaction.TransactionState.LOCAL_CHECKOUT, transaction.getState());
+    verify(notifier).reportCheckOut(transaction, itemDto.getHrid(), itemDto.getBarcode());
+  }
+
+  private InnReachTransaction createLocalTransaction() {
+    var transaction = new InnReachTransaction();
+    transaction.setId(UUID.randomUUID());
+    transaction.setType(InnReachTransaction.TransactionType.LOCAL);
+    transaction.setState(InnReachTransaction.TransactionState.LOCAL_HOLD);
+
+    var hold = new TransactionLocalHold();
+    transaction.setHold(hold);
+
+    return transaction;
+  }
+
+  private StorageLoanDTO createLoanDTO(UUID loanId, UUID itemId, UUID patronId, Date dueDate) {
+    var loan = new StorageLoanDTO();
+    loan.setId(loanId);
+    loan.setItemId(itemId);
+    loan.setUserId(patronId);
+    loan.setDueDate(dueDate);
+
+    return loan;
+  }
+
+  private RequestDTO createRequestDTO(UUID requestId, UUID itemId, RequestDTO.RequestStatus status, UUID servicePointId) {
+    return RequestDTO.builder()
+      .id(requestId)
+      .itemId(itemId)
+      .status(status)
+      .pickupServicePointId(servicePointId)
+      .build();
+  }
+}

--- a/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
@@ -507,6 +507,8 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
     var holding = createInventoryHoldingDTO();
     var item = createInventoryItemDTO();
     var event = createRequestDomainEvent(DomainEventType.UPDATED);
+    event.getData().getNewEntity().setStatus(RequestStatus.OPEN_NOT_YET_FILLED);
+    event.getData().setOldEntity(event.getData().getNewEntity());
     var request = event.getData().getNewEntity();
 
     item.setHoldingsRecordId(holding.getId());


### PR DESCRIPTION
### Purpose
On updating and closing the item request created for Local Hold transaction by any other means (ex.: Request App) the status of the transaction is not updated and central Inn-Reach is not notified with `localcheckout` message.

### Approach
- handle the request update event and on the conditions met check out the item, update the status of the transaction and notify central server

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-427](https://folio-org.atlassian.net/browse/MODINREACH-427)
