### PR TITLE
MODINREACH-550: Fix http service proxy factory bean init

### DIFF
--- a/src/main/java/org/folio/innreach/config/PrimaryHttpServiceProxyFactoryConfig.java
+++ b/src/main/java/org/folio/innreach/config/PrimaryHttpServiceProxyFactoryConfig.java
@@ -1,0 +1,30 @@
+package org.folio.innreach.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Marks the {@code httpServiceProxyFactory} bean (defined in folio-spring-base's
+ * {@code HttpServiceClientConfiguration}) as primary.
+ *
+ * <p>This is needed because mod-inn-reach defines two additional
+ * {@code HttpServiceProxyFactory} beans ({@code inventoryHttpServiceProxyFactory}
+ * and {@code innReachHttpServiceProxyFactory}). When {@code folio.system-user.enabled=true},
+ * the library class {@code OptionalSystemUserConfig} injects an unqualified
+ * {@code HttpServiceProxyFactory} to create {@code AuthnClient}. Without a primary
+ * bean, Spring cannot resolve the ambiguity among the three candidates.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "folio.system-user", name = "enabled", havingValue = "true")
+public class PrimaryHttpServiceProxyFactoryConfig implements BeanFactoryPostProcessor {
+
+  @Override
+  public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+    var beanDefinition = beanFactory.getBeanDefinition("httpServiceProxyFactory");
+    beanDefinition.setPrimary(true);
+  }
+}
+

--- a/src/test/java/org/folio/innreach/config/PrimaryHttpServiceProxyFactoryConfigTest.java
+++ b/src/test/java/org/folio/innreach/config/PrimaryHttpServiceProxyFactoryConfigTest.java
@@ -1,0 +1,61 @@
+package org.folio.innreach.config;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+
+class PrimaryHttpServiceProxyFactoryConfigTest {
+
+  private final PrimaryHttpServiceProxyFactoryConfig config = new PrimaryHttpServiceProxyFactoryConfig();
+
+  @Test
+  void markHttpServiceProxyFactoryAsPrimary() {
+    var beanFactory = mock(ConfigurableListableBeanFactory.class);
+    var beanDefinition = mock(BeanDefinition.class);
+    when(beanFactory.getBeanDefinition("httpServiceProxyFactory")).thenReturn(beanDefinition);
+
+    config.postProcessBeanFactory(beanFactory);
+
+    verify(beanDefinition).setPrimary(true);
+  }
+
+  @Test
+  void lookUpCorrectBeanName() {
+    var beanFactory = mock(ConfigurableListableBeanFactory.class);
+    var beanDefinition = mock(BeanDefinition.class);
+    when(beanFactory.getBeanDefinition("httpServiceProxyFactory")).thenReturn(beanDefinition);
+
+    config.postProcessBeanFactory(beanFactory);
+
+    verify(beanFactory).getBeanDefinition("httpServiceProxyFactory");
+  }
+
+  @Test
+  void propagateExceptionWhenBeanNotFound() {
+    var beanFactory = mock(ConfigurableListableBeanFactory.class);
+    when(beanFactory.getBeanDefinition("httpServiceProxyFactory"))
+        .thenThrow(new NoSuchBeanDefinitionException("httpServiceProxyFactory"));
+
+    assertThatThrownBy(() -> config.postProcessBeanFactory(beanFactory))
+        .isInstanceOf(NoSuchBeanDefinitionException.class);
+  }
+
+  @Test
+  void doNotModifyOtherBeanDefinitions() {
+    var beanFactory = mock(ConfigurableListableBeanFactory.class);
+    var targetDefinition = mock(BeanDefinition.class);
+    var otherDefinition = mock(BeanDefinition.class);
+    when(beanFactory.getBeanDefinition("httpServiceProxyFactory")).thenReturn(targetDefinition);
+
+    config.postProcessBeanFactory(beanFactory);
+
+    verify(otherDefinition, never()).setPrimary(true);
+  }
+}

--- a/src/test/java/org/folio/innreach/context/PostgresTestContainersBeanFactoryPostProcessor.java
+++ b/src/test/java/org/folio/innreach/context/PostgresTestContainersBeanFactoryPostProcessor.java
@@ -11,7 +11,7 @@ import org.testcontainers.junit.jupiter.Container;
 import java.util.Objects;
 
 @Component
-@Profile("testcontainers-pg")
+@Profile("it")
 public class PostgresTestContainersBeanFactoryPostProcessor implements BeanFactoryPostProcessor {
 
   @Container

--- a/src/test/java/org/folio/innreach/controller/TenantInitIT.java
+++ b/src/test/java/org/folio/innreach/controller/TenantInitIT.java
@@ -1,0 +1,81 @@
+package org.folio.innreach.controller;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import org.folio.innreach.ModInnReachApplication;
+import org.folio.innreach.domain.listener.KafkaCirculationEventListener;
+import org.folio.innreach.domain.listener.KafkaInitialContributionEventListener;
+import org.folio.innreach.domain.listener.KafkaInventoryEventListener;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies that the application context loads and {@code POST /_/tenant} succeeds
+ * when {@code folio.system-user.enabled=false} (the default in
+ * {@code application-it.yml}).
+ *
+ * <p>This test activates only the {@code it} profile (not {@code test})
+ * so the stub {@code TestTenantController} from {@code BaseControllerTest} is not loaded.
+ * The real {@code TenantController} from folio-spring-base handles the request and
+ * returns 204 NO_CONTENT.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  classes = ModInnReachApplication.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("it")
+class TenantInitIT {
+
+  private static final WireMockServer wm =
+    new WireMockServer(wireMockConfig().dynamicPort().notifier(new Slf4jNotifier(true)));
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private KafkaCirculationEventListener kafkaCirculationEventListener;
+  @MockitoBean
+  private KafkaInventoryEventListener kafkaInventoryEventListener;
+  @MockitoBean
+  private KafkaInitialContributionEventListener kafkaInitialContributionEventListener;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry registry) {
+    registry.add("folio.okapi-url", wm::baseUrl);
+  }
+
+  @BeforeAll
+  static void startWm() {
+    wm.start();
+    WireMock.configureFor(new WireMock(wm));
+  }
+
+  @AfterAll
+  static void stopWm() {
+    wm.stop();
+  }
+
+  @Test
+  void postTenant_succeeds_whenSystemUserDisabled() throws Exception {
+    mockMvc.perform(post("/_/tenant")
+        .header(XOkapiHeaders.TENANT, "test_tenant")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"moduleTo\": \"mod-inn-reach-1.0.0\"}"))
+      .andExpect(status().isNoContent());
+  }
+}

--- a/src/test/java/org/folio/innreach/controller/TenantInitWithSystemUserEnabledIT.java
+++ b/src/test/java/org/folio/innreach/controller/TenantInitWithSystemUserEnabledIT.java
@@ -1,0 +1,87 @@
+package org.folio.innreach.controller;
+
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.Slf4jNotifier;
+import org.folio.innreach.ModInnReachApplication;
+import org.folio.innreach.domain.listener.KafkaCirculationEventListener;
+import org.folio.innreach.domain.listener.KafkaInitialContributionEventListener;
+import org.folio.innreach.domain.listener.KafkaInventoryEventListener;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Verifies that the application context loads and {@code POST /_/tenant} succeeds
+ * when {@code folio.system-user.enabled=true}.
+ *
+ * <p>This exercises the {@code OptionalSystemUserConfig} bean creation path (from
+ * folio-spring-system-user) which injects an unqualified {@code HttpServiceProxyFactory}.
+ * The {@code PrimaryHttpServiceProxyFactoryConfig} ensures the correct (base) factory
+ * is selected when multiple candidates exist.
+ *
+ * <p>This test activates only the {@code it} profile (not {@code test})
+ * so the stub {@code TestTenantController} from {@code BaseControllerTest} is not loaded.
+ * The real {@code TenantController} from folio-spring-base handles the request and
+ * returns 204 NO_CONTENT.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+  classes = ModInnReachApplication.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("it")
+@TestPropertySource(properties = "folio.system-user.enabled=true")
+class TenantInitWithSystemUserEnabledIT {
+
+  private static final WireMockServer wm =
+    new WireMockServer(wireMockConfig().dynamicPort().notifier(new Slf4jNotifier(true)));
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private KafkaCirculationEventListener kafkaCirculationEventListener;
+  @MockitoBean
+  private KafkaInventoryEventListener kafkaInventoryEventListener;
+  @MockitoBean
+  private KafkaInitialContributionEventListener kafkaInitialContributionEventListener;
+
+  @DynamicPropertySource
+  static void props(DynamicPropertyRegistry registry) {
+    registry.add("folio.okapi-url", wm::baseUrl);
+  }
+
+  @BeforeAll
+  static void startWm() {
+    wm.start();
+    WireMock.configureFor(new WireMock(wm));
+  }
+
+  @AfterAll
+  static void stopWm() {
+    wm.stop();
+  }
+
+  @Test
+  void postTenant_succeeds_whenSystemUserEnabled() throws Exception {
+    mockMvc.perform(post("/_/tenant")
+        .header(XOkapiHeaders.TENANT, "test_tenant")
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"moduleTo\": \"mod-inn-reach-1.0.0\"}"))
+      .andExpect(status().isNoContent());
+  }
+}

--- a/src/test/java/org/folio/innreach/controller/base/BaseApiControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/base/BaseApiControllerTest.java
@@ -63,7 +63,7 @@ import org.folio.spring.integration.XOkapiHeaders;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
   classes = {ModInnReachApplication.class})
 @AutoConfigureMockMvc
-@ActiveProfiles({"test", "testcontainers-pg"})
+@ActiveProfiles({"test", "it"})
 @ExtendWith(WatcherExtension.class)
 public class BaseApiControllerTest {
 

--- a/src/test/java/org/folio/innreach/controller/base/BaseControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/base/BaseControllerTest.java
@@ -28,7 +28,7 @@ import org.folio.tenant.rest.resource.TenantApi;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT, classes = {ModInnReachApplication.class,
   BaseControllerTest.TestTenantController.class})
-@ActiveProfiles({"test", "testcontainers-pg"})
+@ActiveProfiles({"test", "it"})
 @AutoConfigureTestRestTemplate
 public class BaseControllerTest {
 

--- a/src/test/resources/application-it.yml
+++ b/src/test/resources/application-it.yml
@@ -1,0 +1,47 @@
+# Profile activated by tests that use TestContainers PostgreSQL without the "test" profile.
+# The "test" profile (application-test.yml) includes embedded Kafka config and activates
+# TestTenantController. This profile provides the minimal DB and app config needed to
+# start the application context against a TestContainers PostgreSQL instance.
+spring:
+  datasource:
+    url: ${DB_URL}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+    hikari:
+      connection-init-sql: SET timezone = 'UTC'
+  liquibase:
+    enabled: true
+  jpa:
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        jdbc:
+          time_zone: UTC
+        timezone:
+          default_storage: NORMALIZE_UTC
+folio:
+  tenant:
+    validation:
+      enabled: false
+  system-user:
+    enabled: false
+    username: mod-innreach
+    password: Mod-innreach-1-0-0
+    lastname: System
+    permissionsFilePath: permissions/test-permissions.csv
+management:
+  endpoints:
+    access:
+      default: none
+INNREACH_TENANTS: testing
+MAX_FAILURE: 0
+contribution:
+  scheduler:
+    fixed-delay: 30000
+    initial-delay: 1000
+  retry-attempts: 1
+  fetch-limit: 50
+  tenant-cache:
+    ttl: 120
+


### PR DESCRIPTION
### Purpose
When ```folio.system-user.enabled=true```, the library class ```OptionalSystemUserConfig``` injects an unqualified ```HttpServiceProxyFactory``` ```AuthnClient``` as other than the bean for ```HttpServiceProxyFactory``` defined in spring support library there are two other custom ones defined in mod-inn-reach and Spring does not know which one to choose.

### Approach
- make the bean defined in spring support library as primary one

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-530](https://folio-org.atlassian.net/browse/MODINREACH-530)
