### PR TITLE
MODINREACH-577: Fix issues found after migration to Spring-Boot 4.0.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## v4.1.0-SNAPSHOT 2026-XX-XX
+* Fix issues found after migration to Spring Boot v4.0.5 ([MODINREACH-577](https://folio-org.atlassian.net/browse/MODINREACH-577))
+
 ## v4.0.0 2026-04-17
 
 ### Breaking changes
@@ -43,25 +46,6 @@
 * Remove `spring-cloud-starter-openfeign` (replaced by Spring Boot 4 built-in support)
 * Remove `coffee-boots` (no longer needed with Spring Boot 4)
 * Add `lombok-mapstruct-binding 0.2.0`
-
-## v3.5.0-SNAPSHOT 2025-xx-xx
-* [MODINREACH-550](https://folio-org.atlassian.net/browse/MODINREACH-550) - Upgrade to Spring Boot v4.0.5
-
-### Bugs
-* [MODINREACH-503](https://folio-org.atlassian.net/browse/MODINREACH-503) - [INN-Reach] Add missing tokens to API
-* [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Recontribute for requested Item on automatically item hold cancelled transaction.
-* [MODINREACH-485](https://folio-org.atlassian.net/browse/MODINREACH-485) - Bump Spring Boot from 3.4.4 to 3.5.0
-* [MODINREACH-496](https://folio-org.atlassian.net/browse/MODINREACH-496) - Add missing module permission to get holdings sources for INN-Reach circulation endpoints
-* [MODINREACH-467](https://folio-org.atlassian.net/browse/MODINREACH-467) - Assign Item Hold Transaction due date when item checked out to borrowing site
-* [MODINREACH-508](https://folio-org.atlassian.net/browse/MODINREACH-508) - Add missing permissions for INN-Reach circulation endpoints and for System User
-* [MODINREACH-482](https://folio-org.atlassian.net/browse/MODINREACH-482) - Add remove patron hold API to cancel `PATRON_HOLD` transactions with no created virtual item and request
-* [MODINREACH-524](https://folio-org.atlassian.net/browse/MODINREACH-524) - Fix handling Owner Renew Item message (Borrowing Site) and setting correct state
-* [MODINREACH-427](https://folio-org.atlassian.net/browse/MODINREACH-427) - Checkout local hold item on closing of item request and notify inn-reach central server
-* [MODINREACH-532](https://folio-org.atlassian.net/browse/MODINREACH-532) - Remove log message with sensitive information
-* [MODINREACH-531](https://folio-org.atlassian.net/browse/MODINREACH-531) - 414 Request-URI Too Long when calling circulation/requests during getPagingSlipsByServicePoint call
-* [MODINREACH-559](https://folio-org.atlassian.net/browse/MODINREACH-559) - Use GitHub Workflows for Maven
-* [MODINREACH-561](https://folio-org.atlassian.net/browse/MODINREACH-561) - Use circulation/settings instead of mod-configuration for CHECKOUT other_settings
-
 
 ## v3.4.1 2025-04-15
 

--- a/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
@@ -130,9 +130,7 @@ public class ContributionJobRunner {
     log.info("Initial: processing instance iteration event instance id: {}", event.getInstanceId());
 
     var instanceId = event.getInstanceId();
-    boolean isUnknownEvent = isUnknownEvent(event, iterationJobId);
-    log.info("Initial: isUnknownEvent: {}", isUnknownEvent);
-    if (isUnknownEvent) {
+    if (isUnknownEvent(event, iterationJobId)) {
       log.info("Initial: skipping unknown event, current job is: {}, instance id: {}", iterationJobId, instanceId);
       return;
     }
@@ -153,13 +151,11 @@ public class ContributionJobRunner {
     } else if (isContributed(centralServerId, instance)) {
       log.info("Initial: deContributeInstance centralServerId: {}, instanceId: {}", centralServerId, instanceId);
       deContributeInstance(centralServerId, instance, stats);
-    }
-    else {
+    } else {
       // to test if non-eligible increasing count to verify the stopping condition
       log.info("Initial: non-eligible instance id: {}", instanceId);
       ContributionJobRunner.recordsProcessed.put(context.getTenantId(), recordsProcessed.get(context.getTenantId()) == null ? 1
         : recordsProcessed.get(context.getTenantId())+1);
-
     }
 
     if (Objects.equals(recordsProcessed.get(context.getTenantId()), totalRecords.get(context.getTenantId()))) {
@@ -189,8 +185,8 @@ public class ContributionJobRunner {
       boolean contributedInstance = isContributed(centralServerId, instance);
       log.info("runOngoingInstanceContribution:: eligibleInstance: {}, contributedInstance: {}", eligibleInstance, contributedInstance);
       if (!eligibleInstance && !contributedInstance) {
-        log.info("runOngoingInstanceContribution:: skipping ineligible and non-contributed instance with centralServerId {} and instanceId {}", centralServerId, instance.getId());
-        ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_MSG, FAILED);
+        log.info("runOngoingInstanceContribution:: " + SKIPPING_INELIGIBLE_INSTANCE_MSG + ", instance id : {}", instance.getId());
+        ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_INSTANCE_MSG, FAILED);
         return;
       }
       if (eligibleInstance) {
@@ -205,9 +201,6 @@ public class ContributionJobRunner {
         log.info("runOngoingInstanceContribution:: " + DE_CONTRIBUTE_INSTANCE_MSG + ", instance id : {}", instance.getId());
         recordContributionService.deContributeInstance(centralServerId, instance);
         ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, DE_CONTRIBUTED);
-      } else {
-        log.info("runOngoingInstanceContribution:: " + SKIPPING_INELIGIBLE_INSTANCE_MSG + ", instance id : {}", instance.getId());
-        ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_INSTANCE_MSG, FAILED);
       }
     } catch (SocketTimeoutException ex) {
       throw new SocketTimeOutExceptionWrapper(ex.getMessage());
@@ -338,29 +331,6 @@ public class ContributionJobRunner {
     } catch (SocketTimeoutException ex) {
       throw new SocketTimeOutExceptionWrapper(ex.getMessage());
     }
-  }
-
-  public void runItemDeContribution(UUID centralServerId, Instance instance, Item deletedItem) {
-    log.info("Validating item id: {} for de-contribution from central server: {} with instance id: {}", deletedItem.getId(), centralServerId, instance.getId());
-    if (!isContributed(centralServerId, instance, deletedItem)) {
-      log.info("Skipping non-contributed item id: {}, instance id: {}", deletedItem.getId(), instance.getId());
-      return;
-    }
-
-    runOngoing(centralServerId, (context, statistics) -> {
-      log.info("Starting ongoing item de-contribution job {}, centralServer id: {}, item id: {}, instance id: {}", context, centralServerId, deletedItem.getId(), instance.getId());
-
-      if (isEligibleForContribution(centralServerId, instance)) {
-        log.info("Ongoing: de-contributing centralServer id: {}, item id: {}, instance id: {}", centralServerId, deletedItem.getId(), instance.getId());
-        deContributeItem(centralServerId, deletedItem, statistics);
-
-        log.info("Ongoing: re-contributing instance to update bib status centralServer id: {}, item id: {}, instance id: {}", centralServerId, deletedItem.getId(), instance.getId());
-        contributeInstance(centralServerId, instance, statistics);
-      } else {
-        log.info("Ongoing: " + DE_CONTRIBUTE_INSTANCE_MSG+", centralServer id: {}, item id: {}, instance id : {}", centralServerId, deletedItem.getId(), instance.getId());
-        deContributeInstance(centralServerId, instance, statistics);
-      }
-    });
   }
 
   public void runItemDeContribution(UUID centralServerId, Instance instance, Item deletedItem, OngoingContributionStatus ongoingContributionStatus) {

--- a/src/main/java/org/folio/innreach/client/CancellationReasonClient.java
+++ b/src/main/java/org/folio/innreach/client/CancellationReasonClient.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 import org.springframework.web.service.annotation.PostExchange;
@@ -21,7 +22,7 @@ public interface CancellationReasonClient {
   ResultList<CancellationReason> queryReasonByName(@PathVariable("name") String name);
 
   @PostExchange(url = "/cancellation-reasons", contentType = APPLICATION_JSON_VALUE)
-  void createReason(CancellationReason reason);
+  void createReason(@RequestBody CancellationReason reason);
 
   @Builder
   @Data

--- a/src/main/java/org/folio/innreach/client/CirculationClient.java
+++ b/src/main/java/org/folio/innreach/client/CirculationClient.java
@@ -49,16 +49,16 @@ public interface CirculationClient {
   @DeleteExchange("/requests/{requestId}")
   void deleteRequest(@PathVariable("requestId") UUID requestId);
 
-  @PostExchange("/requests")
+  @PostExchange(value = "/requests", contentType = APPLICATION_JSON_VALUE)
   RequestDTO sendRequest(@RequestBody RequestDTO requestDTO);
 
-  @PutExchange("/requests/{requestId}")
+  @PutExchange(value = "/requests/{requestId}", contentType = APPLICATION_JSON_VALUE)
   void updateRequest(@PathVariable("requestId") UUID requestId, @RequestBody RequestDTO request);
 
-  @PostExchange("/requests/{requestId}/move")
+  @PostExchange(value = "/requests/{requestId}/move", contentType = APPLICATION_JSON_VALUE)
   RequestDTO moveRequest(@PathVariable("requestId") UUID requestId, @RequestBody MoveRequestDTO payload);
 
-  @PostExchange("/check-in-by-barcode")
+  @PostExchange(value = "/check-in-by-barcode", contentType = APPLICATION_JSON_VALUE)
   CheckInResponseDTO checkInByBarcode(@RequestBody CheckInRequestDTO checkIn);
 
   @PostExchange(value = "/check-out-by-barcode", contentType = APPLICATION_JSON_VALUE)
@@ -76,16 +76,16 @@ public interface CirculationClient {
   @DeleteExchange("/loans/{loanId}")
   Optional<LoanDTO> deleteLoan(@PathVariable("loanId") UUID loanId);
 
-  @PostExchange("/loans")
+  @PostExchange(value = "/loans", contentType = APPLICATION_JSON_VALUE)
   LoanDTO createLoan(@RequestBody LoanDTO loan);
 
-  @PutExchange("/loans/{loanId}")
+  @PutExchange(value = "/loans/{loanId}", contentType = APPLICATION_JSON_VALUE)
   void updateLoan(@PathVariable("loanId") UUID loanId, @RequestBody LoanDTO loan);
 
-  @PostExchange("/renew-by-id")
+  @PostExchange(value = "/renew-by-id", contentType = APPLICATION_JSON_VALUE)
   LoanDTO renewLoan(@RequestBody RenewByIdDTO renewLoan);
 
-  @PostExchange("/loans/{loanId}/claim-item-returned")
+  @PostExchange(value = "/loans/{loanId}/claim-item-returned", contentType = APPLICATION_JSON_VALUE)
   void claimItemReturned(@PathVariable("loanId") UUID loanId, @RequestBody ClaimItemReturnedRequestDTO payload);
 
 }

--- a/src/main/java/org/folio/innreach/client/CirculationClient.java
+++ b/src/main/java/org/folio/innreach/client/CirculationClient.java
@@ -1,5 +1,7 @@
 package org.folio.innreach.client;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -57,10 +59,10 @@ public interface CirculationClient {
   RequestDTO moveRequest(@PathVariable("requestId") UUID requestId, @RequestBody MoveRequestDTO payload);
 
   @PostExchange("/check-in-by-barcode")
-  CheckInResponseDTO checkInByBarcode(CheckInRequestDTO checkIn);
+  CheckInResponseDTO checkInByBarcode(@RequestBody CheckInRequestDTO checkIn);
 
-  @PostExchange("/check-out-by-barcode")
-  LoanDTO checkOutByBarcode(CheckOutRequestDTO checkOut);
+  @PostExchange(value = "/check-out-by-barcode", contentType = APPLICATION_JSON_VALUE)
+  LoanDTO checkOutByBarcode(@RequestBody CheckOutRequestDTO checkOut);
 
   @GetExchange("/loans?query=(itemId=={itemId})")
   ResultList<LoanDTO> queryLoansByItemId(@PathVariable("itemId") UUID itemId);

--- a/src/main/java/org/folio/innreach/client/HoldingsStorageClient.java
+++ b/src/main/java/org/folio/innreach/client/HoldingsStorageClient.java
@@ -1,5 +1,7 @@
 package org.folio.innreach.client;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -20,10 +22,10 @@ public interface HoldingsStorageClient {
   @DeleteExchange("/holdings/{holdingsRecordId}")
   void deleteHolding(@PathVariable("holdingsRecordId") UUID holdingId);
 
-  @PostExchange("/holdings")
+  @PostExchange(value = "/holdings", contentType = APPLICATION_JSON_VALUE)
   Holding createHolding(@RequestBody Holding holding);
 
-  @PutExchange("/holdings/{holdingId}")
+  @PutExchange(value = "/holdings/{holdingId}", contentType = APPLICATION_JSON_VALUE)
   void updateHolding(@PathVariable UUID holdingId, @RequestBody Holding holding);
 
 }

--- a/src/main/java/org/folio/innreach/client/InstanceContributorTypeClient.java
+++ b/src/main/java/org/folio/innreach/client/InstanceContributorTypeClient.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
@@ -22,7 +23,7 @@ public interface InstanceContributorTypeClient {
   ResultList<NameType> findByQuery(@RequestParam("query") String query);
 
   @PostExchange(contentType = APPLICATION_JSON_VALUE)
-  void createContributorType(NameType nameType);
+  void createContributorType(@RequestBody NameType nameType);
 
   @Builder
   @Data

--- a/src/main/java/org/folio/innreach/client/InstanceTypeClient.java
+++ b/src/main/java/org/folio/innreach/client/InstanceTypeClient.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
@@ -22,7 +23,7 @@ public interface InstanceTypeClient {
   ResultList<InstanceType> findByQuery(@RequestParam("query") String query);
 
   @PostExchange(contentType = APPLICATION_JSON_VALUE)
-  void createInstanceType(InstanceType type);
+  void createInstanceType(@RequestBody InstanceType type);
 
   @Builder
   @Data

--- a/src/main/java/org/folio/innreach/client/InventoryClient.java
+++ b/src/main/java/org/folio/innreach/client/InventoryClient.java
@@ -1,5 +1,7 @@
 package org.folio.innreach.client;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,16 +26,16 @@ public interface InventoryClient {
   @GetExchange("/items?query=hrid=={hrId}")
   ResultList<InventoryItemDTO> getItemsByHrId(@PathVariable("hrId") String hrId);
 
-  @PostExchange("/instances")
+  @PostExchange(value = "/instances", contentType = APPLICATION_JSON_VALUE)
   void createInstance(@RequestBody InventoryInstanceDTO instance);
 
   @GetExchange("/instances?query=(hrid=={hrid})")
   ResultList<InventoryInstanceDTO> queryInstanceByHrid(@PathVariable("hrid") String hrid);
 
-  @PostExchange("/items")
+  @PostExchange(value = "/items", contentType = APPLICATION_JSON_VALUE)
   InventoryItemDTO createItem(@RequestBody InventoryItemDTO item);
 
-  @PutExchange("/items/{itemId}")
+  @PutExchange(value = "/items/{itemId}", contentType = APPLICATION_JSON_VALUE)
   void updateItem(@PathVariable("itemId") UUID itemId, @RequestBody InventoryItemDTO item);
 
   @DeleteExchange("/items/{itemId}")
@@ -55,7 +57,7 @@ public interface InventoryClient {
   ResultList<InventoryItemDTO> queryItemsByIdsAndLocations(@PathVariable("itemIds") String itemIdKey,
                                                            @PathVariable("locationIds") String locationIdKey,
                                                            @RequestParam("limit") int limit);
-  @PostExchange("/items/retrieve")
+  @PostExchange(value = "/items/retrieve", contentType = APPLICATION_JSON_VALUE)
   ResultList<InventoryItemDTO> retrieveItemsByCQLBody(@Valid @RequestBody CQLQueryRequestDto cqlQueryRequestDto);
 
   @GetExchange("/instances?query=id=({instanceIds})")

--- a/src/main/java/org/folio/innreach/client/LocationsClient.java
+++ b/src/main/java/org/folio/innreach/client/LocationsClient.java
@@ -1,8 +1,5 @@
 package org.folio.innreach.client;
 
-import java.util.UUID;
-
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
@@ -16,7 +13,7 @@ public interface LocationsClient {
   @GetExchange
   ResultList<LocationDTO> getLocations(@RequestParam("limit") int limit);
 
-  @GetExchange("?query=primaryServicePoint=={servicePointId}")
-  ResultList<LocationDTO> queryLocationsByServicePoint(@PathVariable("servicePointId") UUID servicePointId, @RequestParam("limit") int limit);
+  @GetExchange()
+  ResultList<LocationDTO> queryLocationsByServicePoint(@RequestParam("query") String query, @RequestParam("limit") int limit);
 
 }

--- a/src/main/java/org/folio/innreach/client/LocationsClient.java
+++ b/src/main/java/org/folio/innreach/client/LocationsClient.java
@@ -13,7 +13,7 @@ public interface LocationsClient {
   @GetExchange
   ResultList<LocationDTO> getLocations(@RequestParam("limit") int limit);
 
-  @GetExchange()
+  @GetExchange
   ResultList<LocationDTO> queryLocationsByServicePoint(@RequestParam("query") String query, @RequestParam("limit") int limit);
 
 }

--- a/src/main/java/org/folio/innreach/client/ServicePointsUsersClient.java
+++ b/src/main/java/org/folio/innreach/client/ServicePointsUsersClient.java
@@ -1,8 +1,6 @@
 package org.folio.innreach.client;
 
-import java.util.UUID;
-
-import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
 
@@ -12,6 +10,6 @@ import org.folio.innreach.domain.dto.folio.inventorystorage.ServicePointUserDTO;
 @HttpExchange("service-points-users")
 public interface ServicePointsUsersClient {
 
-  @GetExchange("?query=userId=={userId}")
-  ResultList<ServicePointUserDTO> findServicePointsUsers(@PathVariable("userId") UUID userId);
+  @GetExchange
+  ResultList<ServicePointUserDTO> findServicePointsUsersByQuery(@RequestParam("query") String query);
 }

--- a/src/main/java/org/folio/innreach/controller/InnReachProxyController.java
+++ b/src/main/java/org/folio/innreach/controller/InnReachProxyController.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
-import lombok.extern.log4j.Log4j2;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.util.MimeTypeUtils;
@@ -18,7 +17,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.folio.innreach.external.service.InnReachExternalService;
 
-@Log4j2
 @RequiredArgsConstructor
 @RestController
 public class InnReachProxyController {
@@ -37,8 +35,6 @@ public class InnReachProxyController {
                                  HttpServletResponse response) throws IOException {
     var d2RRequestUri = getD2RRequestUri(request);
     var innReachResponse = innReachExternalService.callInnReachApi(centralServerId, d2RRequestUri);
-
-    log.info("callInnReachApi:: d2RRequestUri: {}, result response: {}", d2RRequestUri, innReachResponse);
 
     var body = innReachResponse == null ? "" : innReachResponse;
     var bytes = body.getBytes(StandardCharsets.UTF_8);

--- a/src/main/java/org/folio/innreach/controller/InnReachProxyController.java
+++ b/src/main/java/org/folio/innreach/controller/InnReachProxyController.java
@@ -1,10 +1,16 @@
 package org.folio.innreach.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.util.MimeTypeUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -12,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import org.folio.innreach.external.service.InnReachExternalService;
 
+@Log4j2
 @RequiredArgsConstructor
 @RestController
 public class InnReachProxyController {
@@ -25,9 +32,23 @@ public class InnReachProxyController {
     value = "/inn-reach/central-servers/{centralServerId}/d2r/**",
     produces = MimeTypeUtils.APPLICATION_JSON_VALUE
   )
-  public String handleD2RProxyCall(@PathVariable UUID centralServerId, HttpServletRequest request) {
+  public void handleD2RProxyCall(@PathVariable UUID centralServerId,
+                                 HttpServletRequest request,
+                                 HttpServletResponse response) throws IOException {
     var d2RRequestUri = getD2RRequestUri(request);
-    return innReachExternalService.callInnReachApi(centralServerId, d2RRequestUri);
+    var innReachResponse = innReachExternalService.callInnReachApi(centralServerId, d2RRequestUri);
+
+    log.info("callInnReachApi:: d2RRequestUri: {}, result response: {}", d2RRequestUri, innReachResponse);
+
+    var body = innReachResponse == null ? "" : innReachResponse;
+    var bytes = body.getBytes(StandardCharsets.UTF_8);
+
+    response.setStatus(HttpStatus.OK.value());
+    response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+    response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+    response.setContentLength(bytes.length);
+    response.getOutputStream().write(bytes);
+    response.getOutputStream().flush();
   }
 
   private String getD2RRequestUri(HttpServletRequest request) {

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -123,9 +123,9 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
     verifyState(transaction, ITEM_SHIPPED);
 
-    var response = checkInItem(transaction, servicePointId);
-
     transaction.setState(ITEM_RECEIVED);
+
+    var response = checkInItem(transaction, servicePointId);
 
     notifier.reportItemReceived(transaction);
 
@@ -146,9 +146,9 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
     patronHoldService.addItemBarcode(transaction, itemBarcode);
 
-    var response = checkInItem(transaction, servicePointId);
-
     transaction.setState(RECEIVE_UNANNOUNCED);
+
+    var response = checkInItem(transaction, servicePointId);
 
     notifier.reportUnshippedItemReceived(transaction);
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InventoryServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InventoryServiceImpl.java
@@ -32,7 +32,8 @@ public class InventoryServiceImpl implements InventoryService {
   @Override
   public Optional<UUID> findDefaultServicePointIdForUser(UUID userId) {
     log.debug("findDefaultServicePointIdForUser:: parameters userId: {}", userId);
-    return getFirstItem(servicePointsUsersClient.findServicePointsUsers(userId))
+    var cqlQuery = CqlQuery.exactMatch("userId", userId.toString());
+    return getFirstItem(servicePointsUsersClient.findServicePointsUsersByQuery(cqlQuery.getQuery()))
       .map(ServicePointUserDTO::getDefaultServicePointId);
   }
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/PagingSlipServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/PagingSlipServiceImpl.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.tuple.Pair;
+import org.folio.innreach.util.CqlQuery;
 import org.springframework.stereotype.Service;
 
 import org.folio.innreach.client.LocationsClient;
@@ -186,7 +187,8 @@ public class PagingSlipServiceImpl implements PagingSlipService {
   }
 
   private Set<UUID> fetchLocationIdsByServicePoint(UUID servicePointId) {
-    return locationsClient.queryLocationsByServicePoint(servicePointId, FETCH_LIMIT).getResult()
+    var cqlQuery = CqlQuery.exactMatch("primaryServicePoint", servicePointId.toString());
+    return locationsClient.queryLocationsByServicePoint(cqlQuery.getQuery(), FETCH_LIMIT).getResult()
       .stream()
       .map(LocationDTO::getId)
       .collect(toSet());

--- a/src/main/java/org/folio/innreach/domain/service/impl/RecordContributionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/RecordContributionServiceImpl.java
@@ -1,11 +1,16 @@
 package org.folio.innreach.domain.service.impl;
 
+import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
+
 import java.net.SocketTimeoutException;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.folio.innreach.external.exception.InnReachConnectionException;
 import org.folio.innreach.external.exception.InnReachRetryException;
 import org.folio.innreach.external.exception.ServiceSuspendedException;
@@ -147,7 +152,7 @@ public class RecordContributionServiceImpl implements RecordContributionService 
   private InnReachResponse contributeBib(UUID centralServerId, String bibId, BibInfo bib) {
     log.info("Retry happening for contributeBib with bibId: {}",bibId);
     var response = irContributionService.contributeBib(centralServerId, bibId, bib);
-    checkServiceSuspension(response);
+    verifyInnReachContributionResponse(response);
     Assert.isTrue(response.isOk(), "Unexpected contribution response: " + response);
     return response;
   }
@@ -155,33 +160,39 @@ public class RecordContributionServiceImpl implements RecordContributionService 
   private InnReachResponse verifyBibContribution(UUID centralServerId, String bibId) {
     log.info("verifyBibContribution with bibId: {}",bibId);
     var response = irContributionService.lookUpBib(centralServerId, bibId);
-    checkServiceSuspension(response);
+    verifyInnReachContributionResponse(response);
     Assert.isTrue(response.isOk(), "Unexpected verification response: " + response);
     return response;
   }
 
   private InnReachResponse contributeBibItems(String bibId, UUID centralServerId, List<BibItem> bibItems) {
     var response = irContributionService.contributeBibItems(centralServerId, bibId, BibItemsInfo.of(bibItems));
-    checkServiceSuspension(response);
+    verifyInnReachContributionResponse(response);
     Assert.isTrue(response.isOk(), "Unexpected items contribution response: " + response);
     return response;
   }
 
-  private void checkServiceSuspension(InnReachResponse response) {
-    if (response != null && response.getErrors() != null && !response.getErrors().isEmpty()) {
-      InnReachResponse.Error errorResponse = response.getErrors().get(0);
+  private void verifyInnReachContributionResponse(InnReachResponse response) {
+    if (response != null && isNotEmpty(response.getErrors())) {
+      InnReachResponse.Error errorResponse = response.getErrors().getFirst();
 
-      var error = errorResponse!=null ? errorResponse.getReason() : "";
-      String errorMessages = "";
-
-      if (errorResponse!=null && errorResponse.getMessages()!=null && !errorResponse.getMessages().isEmpty()) {
-        errorMessages = errorResponse.getMessages().get(0);
+      var errorReason = Optional.ofNullable(errorResponse)
+        .map(InnReachResponse.Error::getReason)
+        .orElse("");
+      if (StringUtils.isNotBlank(errorReason)) {
+        log.warn("verifyInnReachContributionResponse:: error reason: {}", errorReason);
       }
-      log.info("checkServiceSuspension error: {}", error);
-      if (error.contains(CONTRIBUTION_IS_CURRENTLY_SUSPENDED)) {
+      if (errorReason.contains(CONTRIBUTION_IS_CURRENTLY_SUSPENDED)) {
         log.info("Contribution to d2irm is currently suspended error message occurred");
         throw new ServiceSuspendedException(CONTRIBUTION_IS_CURRENTLY_SUSPENDED);
       }
+
+      var errorMessages = Optional.ofNullable(errorResponse)
+        .map(InnReachResponse.Error::getMessages)
+        .filter(CollectionUtils::isNotEmpty)
+        .map(List::getFirst)
+        .orElse("");
+
       if (errorMessages.contains(CONNECTIONS_ALLOWED_FROM_THIS_SERVER)) {
         log.info("Allowable maximum Connection limit error message occurred");
         throw new InnReachConnectionException("Only 5 connections allowed from this server");

--- a/src/main/java/org/folio/innreach/external/client/InnReachClient.java
+++ b/src/main/java/org/folio/innreach/external/client/InnReachClient.java
@@ -8,6 +8,7 @@ import static org.folio.innreach.external.InnReachHeaders.X_TO_CODE;
 
 import java.net.URI;
 
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.service.annotation.GetExchange;
 import org.springframework.web.service.annotation.HttpExchange;
@@ -27,7 +28,7 @@ public interface InnReachClient {
                          @RequestHeader(AUTHORIZATION) String authorizationHeader,
                          @RequestHeader(X_FROM_CODE) String xFromCode,
                          @RequestHeader(X_TO_CODE) String xToCode,
-                         Object dto);
+                         @RequestBody Object dto);
 
   @PostExchange
   String postInnReachApi(URI baseUri,

--- a/src/main/java/org/folio/innreach/external/client/config/HttpInnReachServiceClientConfiguration.java
+++ b/src/main/java/org/folio/innreach/external/client/config/HttpInnReachServiceClientConfiguration.java
@@ -1,13 +1,10 @@
 package org.folio.innreach.external.client.config;
 
-import java.util.List;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpStatusCode;
-import org.springframework.http.MediaType;
-import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.JacksonJsonHttpMessageConverter;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.support.NotFoundRestClientAdapterDecorator;
@@ -21,18 +18,13 @@ public class HttpInnReachServiceClientConfiguration {
 
   @Bean("innReachRestClientBuilder")
   public RestClient.Builder innReachRestClientBuilder(InnReachErrorHandler errorHandler, JsonMapper jsonMapper) {
-    // StringHttpMessageConverter must be registered first so that @HttpExchange methods
-    // returning String receive the raw JSON body instead of Jackson attempting deserialization.
-    var stringConverter = new StringHttpMessageConverter();
-    stringConverter.setSupportedMediaTypes(List.of(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON, MediaType.ALL));
-
     return RestClient.builder()
       .defaultStatusHandler(HttpStatusCode::isError,
         ((request, response) -> errorHandler.handle(response)))
-      .configureMessageConverters(configurer ->
-        configurer
-          .addCustomConverter(stringConverter)
-          .addCustomConverter(new JacksonJsonHttpMessageConverter(jsonMapper))
+      .configureMessageConverters(configurer -> configurer
+        .registerDefaults()
+        .withJsonConverter(new JacksonJsonHttpMessageConverter(jsonMapper))
+        .configureMessageConvertersList(converters -> converters.addFirst(new RawJsonStringHttpMessageConverter()))
       );
   }
 

--- a/src/main/java/org/folio/innreach/external/client/config/RawJsonStringHttpMessageConverter.java
+++ b/src/main/java/org/folio/innreach/external/client/config/RawJsonStringHttpMessageConverter.java
@@ -1,0 +1,82 @@
+package org.folio.innreach.external.client.config;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.http.converter.SmartHttpMessageConverter;
+
+/**
+ * A {@link SmartHttpMessageConverter} that reads {@code application/json} responses as raw
+ * {@link String} without any Jackson deserialization/re-serialization. This ensures the JSON
+ * body is returned exactly as received from the server.
+ *
+ * <p>This converter only supports {@link String} as the target type and is intended to be
+ * registered before Jackson converters so that {@code @HttpExchange} methods returning
+ * {@code String} receive the unmodified response body.</p>
+ */
+public class RawJsonStringHttpMessageConverter implements SmartHttpMessageConverter<String> {
+
+  private static final List<MediaType> SUPPORTED_MEDIA_TYPES =
+    List.of(MediaType.APPLICATION_JSON, MediaType.TEXT_PLAIN, MediaType.ALL);
+
+  @Override
+  public boolean canRead(ResolvableType type, MediaType mediaType) {
+    return String.class == type.toClass() && isSupportedMediaType(mediaType);
+  }
+
+  @Override
+  public boolean canWrite(ResolvableType targetType, Class<?> valueClass, MediaType mediaType) {
+    return String.class == valueClass && isSupportedMediaType(mediaType);
+  }
+
+  @Override
+  public List<MediaType> getSupportedMediaTypes() {
+    return SUPPORTED_MEDIA_TYPES;
+  }
+
+  @Override
+  public String read(ResolvableType type, HttpInputMessage inputMessage,
+                     Map<String, Object> hints) throws IOException, HttpMessageNotReadableException {
+    Charset charset = getCharset(inputMessage);
+    return new String(inputMessage.getBody().readAllBytes(), charset);
+  }
+
+  @Override
+  public void write(String value, ResolvableType type, MediaType contentType,
+                    HttpOutputMessage outputMessage, Map<String, Object> hints)
+    throws IOException, HttpMessageNotWritableException {
+    Charset charset = (contentType != null && contentType.getCharset() != null)
+      ? contentType.getCharset() : StandardCharsets.UTF_8;
+    outputMessage.getBody().write(value.getBytes(charset));
+  }
+
+  private boolean isSupportedMediaType(MediaType mediaType) {
+    if (mediaType == null) {
+      return true;
+    }
+    for (MediaType supported : SUPPORTED_MEDIA_TYPES) {
+      if (supported.includes(mediaType)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private Charset getCharset(HttpInputMessage inputMessage) {
+    MediaType contentType = inputMessage.getHeaders().getContentType();
+    if (contentType != null && contentType.getCharset() != null) {
+      return contentType.getCharset();
+    }
+    return StandardCharsets.UTF_8;
+  }
+}
+

--- a/src/main/java/org/folio/innreach/external/service/impl/InnReachContributionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/external/service/impl/InnReachContributionServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.apache.commons.collections4.CollectionUtils;
 import org.folio.innreach.external.exception.InnReachConnectionException;
 import org.folio.innreach.external.exception.ServiceSuspendedException;
 import org.springframework.stereotype.Service;
@@ -96,7 +97,7 @@ public class InnReachContributionServiceImpl implements InnReachContributionServ
       var error = errorResponse!=null ? errorResponse.getReason() : "";
       String errorMessages = "";
 
-      if(errorResponse!=null && errorResponse.getMessages()!=null && !errorResponse.getMessages().isEmpty()) {
+      if (errorResponse!=null && CollectionUtils.isNotEmpty(errorResponse.getMessages())) {
         errorMessages = errorResponse.getMessages().get(0);
       }
       log.info("checkServiceSuspension:: error is : {}",error);
@@ -104,7 +105,7 @@ public class InnReachContributionServiceImpl implements InnReachContributionServ
       if (error.contains(CONTRIBUTION_IS_CURRENTLY_SUSPENDED)) {
         throw new ServiceSuspendedException(CONTRIBUTION_IS_CURRENTLY_SUSPENDED);
       }
-      if(errorMessages.contains(CONNECTIONS_ALLOWED_FROM_THIS_SERVER)) {
+      if (errorMessages.contains(CONNECTIONS_ALLOWED_FROM_THIS_SERVER)) {
         log.info("Allowable maximum Connection limit error message occurred");
         throw new InnReachConnectionException("Only 5 connections allowed from this server");
       }

--- a/src/main/java/org/folio/innreach/external/service/impl/InnReachExternalServiceImpl.java
+++ b/src/main/java/org/folio/innreach/external/service/impl/InnReachExternalServiceImpl.java
@@ -29,12 +29,16 @@ public class InnReachExternalServiceImpl implements InnReachExternalService {
 
     var accessTokenDTO = innReachAuthExternalService.getAccessToken(connectionDetailsDTO);
 
-    return innReachClient.callInnReachApi(
+    var response = innReachClient.callInnReachApi(
       buildInnReachRequestUrl(connectionDetailsDTO.getConnectionUrl(), innReachRequestUri),
       buildBearerAuthHeader(accessTokenDTO.getAccessToken()),
       connectionDetailsDTO.getLocalCode(),
       connectionDetailsDTO.getCentralCode()
     );
+
+    log.info("callInnReachApi:: innReachRequestUri: {}, result response: {}", innReachRequestUri, response);
+
+    return response;
   }
 
   @Override

--- a/src/main/java/org/folio/innreach/external/service/impl/InnReachExternalServiceImpl.java
+++ b/src/main/java/org/folio/innreach/external/service/impl/InnReachExternalServiceImpl.java
@@ -29,16 +29,12 @@ public class InnReachExternalServiceImpl implements InnReachExternalService {
 
     var accessTokenDTO = innReachAuthExternalService.getAccessToken(connectionDetailsDTO);
 
-    var response = innReachClient.callInnReachApi(
+    return innReachClient.callInnReachApi(
       buildInnReachRequestUrl(connectionDetailsDTO.getConnectionUrl(), innReachRequestUri),
       buildBearerAuthHeader(accessTokenDTO.getAccessToken()),
       connectionDetailsDTO.getLocalCode(),
       connectionDetailsDTO.getCentralCode()
     );
-
-    log.info("callInnReachApi:: innReachRequestUri: {}, result response: {}", innReachRequestUri, response);
-
-    return response;
   }
 
   @Override

--- a/src/test/java/org/folio/innreach/batch/contribution/service/ContributionJobRunnerTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/ContributionJobRunnerTest.java
@@ -2,6 +2,7 @@ package org.folio.innreach.batch.contribution.service;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.folio.innreach.batch.contribution.ContributionJobContextManager.beginContributionJobContext;
+import static org.folio.innreach.util.InnReachConstants.SKIPPING_INELIGIBLE_INSTANCE_MSG;
 import static org.folio.innreach.util.InnReachConstants.SKIPPING_INELIGIBLE_MSG;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
@@ -296,7 +297,7 @@ class ContributionJobRunnerTest {
     jobRunner.runOngoingInstanceContribution(CENTRAL_SERVER_ID, instance, ongoingJob);
 
     verify(recordContributor, never()).deContributeInstance(any(), any());
-    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, SKIPPING_INELIGIBLE_MSG, ContributionStatus.FAILED);
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, SKIPPING_INELIGIBLE_INSTANCE_MSG, ContributionStatus.FAILED);
   }
 
   @SneakyThrows
@@ -451,60 +452,6 @@ class ContributionJobRunnerTest {
 
     verify(recordContributor, never()).contributeItems(any(), any(), anyList());
     verify(contributionService, never()).createOngoingContribution(any());
-  }
-
-  @SneakyThrows
-  @Test
-  void runItemDeContribution_shouldDeContribute() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Instance.class))).thenReturn(true);
-    when(contributionService.createOngoingContribution(any())).thenReturn(contribution);
-    when(recordContributor.isContributed(any(), any(), any(Item.class))).thenReturn(true);
-
-    jobRunner.runItemDeContribution(CENTRAL_SERVER_ID, instance, item);
-
-    verify(recordContributor).deContributeItem(any(), any());
-    verify(recordContributor).contributeInstance(any(), any());
-  }
-
-  @SneakyThrows
-  @Test
-  void runItemDeContribution_shouldSkipNonContributed() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(recordContributor.isContributed(any(), any(), any())).thenReturn(false);
-
-    jobRunner.runItemDeContribution(CENTRAL_SERVER_ID, instance, item);
-
-    verify(recordContributor, never()).deContributeItem(any(), any());
-    verify(recordContributor, never()).contributeInstance(any(), any());
-  }
-
-  @SneakyThrows
-  @Test
-  void runItemDeContribution_shouldDeContributeInstance() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Instance.class))).thenReturn(false);
-    when(contributionService.createOngoingContribution(any())).thenReturn(contribution);
-    when(recordContributor.isContributed(any(), any(), any())).thenReturn(true);
-
-    jobRunner.runItemDeContribution(CENTRAL_SERVER_ID, instance, item);
-
-    verify(recordContributor).deContributeInstance(any(), any());
   }
 
   @Test

--- a/src/test/java/org/folio/innreach/batch/contribution/service/OngoingContributionEventProcessorTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/OngoingContributionEventProcessorTest.java
@@ -42,6 +42,7 @@ import static org.folio.innreach.fixture.ContributionFixture.createItem;
 import static org.folio.innreach.util.InnReachConstants.INVALID_CENTRAL_SERVER_ID;
 import static org.folio.innreach.util.InnReachConstants.MARC_ERROR_MSG;
 import static org.folio.innreach.util.InnReachConstants.RETRY_LIMIT_MESSAGE;
+import static org.folio.innreach.util.InnReachConstants.SKIPPING_INELIGIBLE_INSTANCE_MSG;
 import static org.folio.innreach.util.InnReachConstants.SKIPPING_INELIGIBLE_MSG;
 import static org.folio.innreach.util.InnReachConstants.UNKNOWN_TYPE_MESSAGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -879,7 +880,7 @@ class OngoingContributionEventProcessorTest extends BaseControllerTest {
     await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() ->
       verify(ongoingContributionStatusRepository, times(2)).save(any()));
     assertEquals(FAILED, ongoingContributionStatus.getStatus());
-    assertEquals(SKIPPING_INELIGIBLE_MSG, ongoingContributionStatus.getError());
+    assertEquals(SKIPPING_INELIGIBLE_INSTANCE_MSG, ongoingContributionStatus.getError());
   }
 
   @Test

--- a/src/test/java/org/folio/innreach/controller/InnReachProxyControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachProxyControllerTest.java
@@ -1,15 +1,26 @@
 package org.folio.innreach.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.MediaType;
 
 import org.folio.innreach.controller.base.BaseControllerTest;
 import org.folio.innreach.external.service.InnReachExternalService;
@@ -19,6 +30,9 @@ class InnReachProxyControllerTest extends BaseControllerTest {
 
   @Autowired
   private TestRestTemplate testRestTemplate;
+
+  @LocalServerPort
+  private int port;
 
   @MockitoBean
   private InnReachExternalService innReachExternalService;
@@ -32,6 +46,45 @@ class InnReachProxyControllerTest extends BaseControllerTest {
     assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
 
     verify(innReachExternalService).callInnReachApi(UUID.fromString("edab6baf-c696-42b1-89bb-1bbb8759b0d2"), innReachUri);
+  }
+
+  @Test
+  void should_returnReadableJsonExactlyAsReceivedFromInnReach() throws java.io.IOException, InterruptedException {
+    String serverJson = """
+        {
+                "status": "ok",
+                "reason": "success",
+                "errors": [],
+                "itemTypeList": [
+                  {
+                      "centralItemType": 200,
+                      "description": "IR Book"
+                  },
+                  {
+                      "centralItemType": 201,
+                      "description": "Digital Media"
+                  }
+             ]
+        }""";
+
+    when(innReachExternalService.callInnReachApi(any(UUID.class), any(String.class))).thenReturn(serverJson);
+
+    // Use the raw JDK HttpClient to fetch the body as bytes without any JSON decoding.
+    var httpClient = HttpClient.newHttpClient();
+    var httpRequest = HttpRequest.newBuilder()
+      .uri(URI.create("http://localhost:" + port
+        + "/inn-reach/central-servers/edab6baf-c696-42b1-89bb-1bbb8759b0d2/d2r/contribution/itemtypes?limit=1000"))
+      .GET()
+      .build();
+
+    HttpResponse<byte[]> response = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofByteArray());
+
+    assertTrue(response.statusCode() >= 200 && response.statusCode() < 300);
+    String contentType = response.headers().firstValue("Content-Type").orElse("");
+    assertThat(MediaType.parseMediaType(contentType).isCompatibleWith(MediaType.APPLICATION_JSON)).isTrue();
+    // Body must be the exact readable JSON the central server sent (no base64, no extra quoting,
+    // no Jackson re-indentation).
+    assertThat(new String(response.body(), StandardCharsets.UTF_8)).isEqualTo(serverJson);
   }
 
   private static List<String> innReachUriList() {

--- a/src/test/java/org/folio/innreach/controller/InnReachProxyControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachProxyControllerTest.java
@@ -28,6 +28,8 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 class InnReachProxyControllerTest extends BaseControllerTest {
 
+  private static final String CENTRAL_SERVER_ID = "edab6baf-c696-42b1-89bb-1bbb8759b0d2";
+
   @Autowired
   private TestRestTemplate testRestTemplate;
 
@@ -40,12 +42,13 @@ class InnReachProxyControllerTest extends BaseControllerTest {
   @ParameterizedTest
   @MethodSource("innReachUriList")
   void should_handleAllRequestsWithD2RSuffixInUrl(String innReachUri) {
-    var responseEntity = testRestTemplate.getForEntity(
-      "/inn-reach/central-servers/edab6baf-c696-42b1-89bb-1bbb8759b0d2/d2r" + innReachUri, String.class);
+    var url = String.format("/inn-reach/central-servers/%s/d2r%s", CENTRAL_SERVER_ID, innReachUri);
+
+    var responseEntity = testRestTemplate.getForEntity(url, String.class);
 
     assertTrue(responseEntity.getStatusCode().is2xxSuccessful());
 
-    verify(innReachExternalService).callInnReachApi(UUID.fromString("edab6baf-c696-42b1-89bb-1bbb8759b0d2"), innReachUri);
+    verify(innReachExternalService).callInnReachApi(UUID.fromString(CENTRAL_SERVER_ID), innReachUri);
   }
 
   @Test

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerIT.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerIT.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
 import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -41,10 +42,29 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
 
   private static final String CHECK_OUT_ITEM_HOLD_ENDPOINT =
     "/inn-reach/transactions/{itemBarcode}/check-out-item/{servicePointId}";
+  private static final String GET_TRANSACTION_ENDPOINT = "/inn-reach/transactions/{id}";
+  private static final String GET_ALL_TRANSACTIONS_ENDPOINT = "/inn-reach/transactions";
+  private static final String CHECK_IN_PATRON_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/receive-item/{servicePointId}";
+  private static final String CANCEL_ITEM_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/itemhold/cancel";
+  private static final String REMOVE_PATRON_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/patronhold/remove";
 
   private static final String PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE = "DEF-def-5678";
   private static final String CHECK_OUT_BY_BARCODE_URL = "/circulation/check-out-by-barcode";
+  private static final String CHECK_IN_BY_BARCODE_URL = "/circulation/check-in-by-barcode";
   private static final UUID SERVICE_POINT_ID = UUID.randomUUID();
+
+  // Transaction IDs from pre-populate-inn-reach-transaction.sql
+  private static final String PATRON_HOLD_TRANSACTION_ID = "0aab1720-14b4-4210-9a19-0d0bf1cd64d3";
+  private static final String ITEM_HOLD_TRANSACTION_ID = "ab2393a1-acc4-4849-82ac-8cc0c37339e1";
+
+  // Transaction ID from pre-populate-transaction-item-shipped.sql (state=ITEM_SHIPPED, type=PATRON)
+  private static final String ITEM_SHIPPED_TRANSACTION_ID = "7106c3ac-890a-4126-bf9b-a10b67555b6e";
+
+  // Item/request IDs from pre-populated data
+  private static final String PATRON_HOLD_REQUEST_ID = "ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a";
 
   @MockitoBean
   private InnReachExternalService innReachExternalService;
@@ -64,10 +84,8 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
     "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
   })
   void checkOutItemHoldItem_success() {
-    // Stub the check-out-by-barcode endpoint that CirculationClient.checkOutByBarcode calls
     stubPost(CHECK_OUT_BY_BARCODE_URL, "circulation/checkout-response.json");
 
-    // Stub the INN-Reach external call made by the notifier (reportItemShipped)
     when(innReachExternalService.postInnReachApi(any(), any(), any()))
       .thenReturn("ok");
 
@@ -89,6 +107,146 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
     assertNotNull(response.getTransaction());
     assertNotNull(response.getFolioCheckOut());
     assertEquals(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE, response.getFolioCheckOut().getItem().getBarcode());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void getInnReachTransaction_success() {
+    mockMvc.perform(get(GET_TRANSACTION_ENDPOINT, PATRON_HOLD_TRANSACTION_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.id").value(PATRON_HOLD_TRANSACTION_ID))
+      .andExpect(jsonPath("$.state").value("PATRON_HOLD"))
+      .andExpect(jsonPath("$.type").value("PATRON"));
+  }
+
+  @SneakyThrows
+  @Test
+  void getInnReachTransaction_notFound() {
+    mockMvc.perform(get(GET_TRANSACTION_ENDPOINT, UUID.randomUUID())
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isNotFound());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void getAllTransactions_success() {
+    mockMvc.perform(get(GET_ALL_TRANSACTIONS_ENDPOINT)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.totalRecords").value(3))
+      .andExpect(jsonPath("$.transactions").isArray())
+      .andExpect(jsonPath("$.transactions.length()").value(3));
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void getAllTransactions_withPagination() {
+    mockMvc.perform(get(GET_ALL_TRANSACTIONS_ENDPOINT)
+        .param("offset", "0")
+        .param("limit", "1")
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.totalRecords").value(3))
+      .andExpect(jsonPath("$.transactions.length()").value(1));
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-transaction-item-shipped.sql"
+  })
+  void checkInPatronHoldItem_success() {
+    stubPost(CHECK_IN_BY_BARCODE_URL, "circulation/checkin-response.json");
+
+    // Stub request lookup for handleItemWithCanceledRequest
+    stubGet("/circulation/requests/" + PATRON_HOLD_REQUEST_ID, "circulation/open-request-response.json");
+
+    when(innReachExternalService.postInnReachApi(any(), any(), any()))
+      .thenReturn("ok");
+
+    mockMvc.perform(post(CHECK_IN_PATRON_HOLD_ENDPOINT,
+        ITEM_SHIPPED_TRANSACTION_ID, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.transaction").exists())
+      .andExpect(jsonPath("$.transaction.state").value("ITEM_RECEIVED"))
+      .andExpect(jsonPath("$.folioCheckIn").exists());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkInPatronHoldItem_wrongState_returnsBadRequest() {
+    // Patron hold transaction is in PATRON_HOLD state, not ITEM_SHIPPED
+    mockMvc.perform(post(CHECK_IN_PATRON_HOLD_ENDPOINT,
+        PATRON_HOLD_TRANSACTION_ID, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isBadRequest());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void cancelItemHold_success() {
+    mockMvc.perform(post(CANCEL_ITEM_HOLD_ENDPOINT, ITEM_HOLD_TRANSACTION_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"cancellationReasonId\":\"75187e8d-e25a-47a7-89ad-23ba612bb5aa\"}")
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isNoContent());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-broken_patron_hold_transaction.sql"
+  })
+  void removePatronHold_success() {
+    mockMvc.perform(post(REMOVE_PATRON_HOLD_ENDPOINT, PATRON_HOLD_TRANSACTION_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.state").value("CANCEL_REQUEST"));
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkOutItemHoldItem_wrongBarcode_returnsNotFound() {
+    mockMvc.perform(post(CHECK_OUT_ITEM_HOLD_ENDPOINT,
+        "NONEXISTENT-BARCODE", SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isNotFound());
   }
 }
 

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerIT.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerIT.java
@@ -1,0 +1,94 @@
+package org.folio.innreach.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.context.jdbc.Sql.ExecutionPhase.AFTER_TEST_METHOD;
+import static org.springframework.test.context.jdbc.SqlMergeMode.MergeMode.MERGE;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.UUID;
+
+import tools.jackson.databind.ObjectMapper;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.SqlMergeMode;
+
+import org.folio.innreach.controller.base.BaseApiControllerTest;
+import org.folio.innreach.dto.TransactionCheckOutResponseDTO;
+import org.folio.innreach.external.service.InnReachExternalService;
+
+@Sql(
+  scripts = {
+    "classpath:db/central-server/clear-central-server-tables.sql",
+    "classpath:db/inn-reach-transaction/clear-inn-reach-transaction-tables.sql"
+  },
+  executionPhase = AFTER_TEST_METHOD
+)
+@SqlMergeMode(MERGE)
+@ExtendWith(MockitoExtension.class)
+class InnReachTransactionControllerIT extends BaseApiControllerTest {
+
+  private static final String CHECK_OUT_ITEM_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{itemBarcode}/check-out-item/{servicePointId}";
+
+  private static final String PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE = "DEF-def-5678";
+  private static final String CHECK_OUT_BY_BARCODE_URL = "/circulation/check-out-by-barcode";
+  private static final UUID SERVICE_POINT_ID = UUID.randomUUID();
+
+  @MockitoBean
+  private InnReachExternalService innReachExternalService;
+
+  @Autowired
+  private ObjectMapper objectMapper;
+
+  @BeforeEach
+  void setup() {
+    wm.resetAll();
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkOutItemHoldItem_success() {
+    // Stub the check-out-by-barcode endpoint that CirculationClient.checkOutByBarcode calls
+    stubPost(CHECK_OUT_BY_BARCODE_URL, "circulation/checkout-response.json");
+
+    // Stub the INN-Reach external call made by the notifier (reportItemShipped)
+    when(innReachExternalService.postInnReachApi(any(), any(), any()))
+      .thenReturn("ok");
+
+    var result = mockMvc.perform(post(CHECK_OUT_ITEM_HOLD_ENDPOINT,
+        PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.folioCheckOut").exists())
+      .andExpect(jsonPath("$.folioCheckOut.id").value("a1b2c3d4-e5f6-7890-abcd-ef1234567890"))
+      .andExpect(jsonPath("$.folioCheckOut.item.barcode").value(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE))
+      .andExpect(jsonPath("$.transaction").exists())
+      .andExpect(jsonPath("$.transaction.state").value("ITEM_SHIPPED"))
+      .andReturn();
+
+    var response = objectMapper.readValue(
+      result.getResponse().getContentAsString(), TransactionCheckOutResponseDTO.class);
+
+    assertNotNull(response.getTransaction());
+    assertNotNull(response.getFolioCheckOut());
+    assertEquals(PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE, response.getFolioCheckOut().getItem().getBarcode());
+  }
+}
+

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -188,9 +188,9 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
 
   private static final UUID PRE_POPULATED_FOLIO_ITEM_ID = UUID.fromString("4def31b0-2b60-4531-ad44-7eab60fa5428");
   private static final UUID PRE_POPULATED_FOLIO_LOAN_ID = UUID.fromString("06e820e3-71a0-455e-8c73-3963aea677d4");
-  private static final UUID PRE_POPULATE_USER_ID = UUID.fromString("f75ffab1-2e2f-43be-b159-3031e2cfc458");
-  private final static UUID PRE_POPULATED_DEFAULT_SERVICE_POINT_ID = UUID.fromString("56f48d94-96e6-4eae-970b-b0e346ec02f0");
-  private final static UUID PRE_POPULATED_USER_ID = UUID.fromString("ef58f191-ec62-44bb-a571-d59c536bcf4a");
+  private static final String PRE_POPULATE_USER_ID_QUERY = "userId==" + cqlEncode("f75ffab1-2e2f-43be-b159-3031e2cfc458");
+  private static final UUID PRE_POPULATED_DEFAULT_SERVICE_POINT_ID = UUID.fromString("56f48d94-96e6-4eae-970b-b0e346ec02f0");
+  private static final UUID PRE_POPULATED_USER_ID = UUID.fromString("ef58f191-ec62-44bb-a571-d59c536bcf4a");
 
   private static final UUID PRE_POPULATED_LOCAL_HOLD_TRANSACTION_ID = UUID.fromString("79b0a1fb-55be-4e55-9d84-01303aaec1ce");
   private static final UUID PRE_POPULATED_PATRON_HOLD_TRANSACTION_ID = UUID.fromString("0aab1720-14b4-4210-9a19-0d0bf1cd64d3");
@@ -1912,6 +1912,12 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     mockFindRequest(PRE_POPULATED_PATRON_HOLD_REQUEST_ID, CLOSED_CANCELLED);
 
     modifyTransactionState(PRE_POPULATED_PATRON_HOLD_TRANSACTION_ID, state);
+    modifyTransaction(PRE_POPULATED_PATRON_HOLD_TRANSACTION_ID, t -> {
+      t.getHold().setFolioItemId(null);
+      t.getHold().setFolioHoldingId(null);
+      t.getHold().setFolioInstanceId(null);
+      t.getHold().setFolioLoanId(null);
+    });
     var cancelPatronHold = createCancelTransactionHold();
 
     var responseEntity = testRestTemplate.postForEntity(
@@ -1931,6 +1937,11 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     verify(circulationClient, never()).updateRequest(eq(PRE_POPULATED_PATRON_HOLD_REQUEST_ID), any());
     verify(actionNotifier).reportCancelItemHold(any());
     verify(innReachClient).postInnReachApi(any(), anyString(), anyString(), anyString());
+
+    verify(inventoryClient, never()).deleteItem(any());
+    verify(holdingsStorageClient, never()).deleteHolding(any());
+    verify(inventoryClient, never()).deleteInstance(any());
+    verify(circulationClient, never()).deleteLoan(any());
   }
 
   @ParameterizedTest
@@ -2385,13 +2396,13 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
     modifyTransactionState(PRE_POPULATED_ITEM_HOLD_TRANSACTION_ID, ITEM_RECEIVED);
 
     when(circulationClient.queryRequestsByItemId(PRE_POPULATED_FOLIO_ITEM_ID)).thenReturn(getNotOpenRequests());
-    when(servicePointsUsersClient.findServicePointsUsers(PRE_POPULATE_USER_ID)).thenReturn(getServicePointUsers());
+    when(servicePointsUsersClient.findServicePointsUsersByQuery(PRE_POPULATE_USER_ID_QUERY)).thenReturn(getServicePointUsers());
 
     var responseEntity = testRestTemplate.postForEntity(
       ITEM_HOLD_RECALL_ENDPOINT, null, Void.class, PRE_POPULATED_ITEM_HOLD_TRANSACTION_ID);
 
     assertEquals(HttpStatus.NO_CONTENT, responseEntity.getStatusCode());
-    verify(servicePointsUsersClient).findServicePointsUsers(any());
+    verify(servicePointsUsersClient).findServicePointsUsersByQuery(any());
     verify(circulationClient).queryRequestsByItemId(any());
     verify(circulationClient).sendRequest(any());
   }

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -545,7 +545,8 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     var transactionHoldDTO = createTransactionHoldDTO();
 
     when(circulationClient.findRequest(transaction.getHold().getFolioRequestId())).thenReturn(Optional.of(createRequestDTO()));
-    when(servicePointsUsersClient.findServicePointsUsers(eq(PRE_POPULATED_PATRON2_ID))).thenReturn(ResultList.asSinglePage(createServicePointUserDTO()));
+    when(servicePointsUsersClient.findServicePointsUsersByQuery("userId==" + cqlEncode(PRE_POPULATED_PATRON2_ID.toString())))
+      .thenReturn(ResultList.asSinglePage(createServicePointUserDTO()));
     when(circulationClient.checkOutByBarcode(any(CheckOutRequestDTO.class))).thenReturn(new LoanDTO().id(NEW_LOAN_ID));
 
     var responseEntity = testRestTemplate.exchange(

--- a/src/test/java/org/folio/innreach/external/client/config/RawJsonStringHttpMessageConverterTest.java
+++ b/src/test/java/org/folio/innreach/external/client/config/RawJsonStringHttpMessageConverterTest.java
@@ -1,0 +1,182 @@
+package org.folio.innreach.external.client.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.ResolvableType;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.MediaType;
+
+@ExtendWith(MockitoExtension.class)
+class RawJsonStringHttpMessageConverterTest {
+
+  private final RawJsonStringHttpMessageConverter converter = new RawJsonStringHttpMessageConverter();
+
+  @Mock
+  private HttpInputMessage inputMessage;
+
+  @Mock
+  private HttpOutputMessage outputMessage;
+
+  @Test
+  void canRead_withStringTypeAndJsonMediaType_returnsTrue() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canRead_withStringTypeAndTextPlainMediaType_returnsTrue() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), MediaType.TEXT_PLAIN));
+  }
+
+  @Test
+  void canRead_withStringTypeAndNullMediaType_returnsTrue() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), null));
+  }
+
+  @Test
+  void canRead_withNonStringType_returnsFalse() {
+    assertFalse(converter.canRead(ResolvableType.forClass(Integer.class), MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canRead_withStringTypeAndXmlMediaType_returnsTrueBecauseAllIsSupported() {
+    assertTrue(converter.canRead(ResolvableType.forClass(String.class), MediaType.APPLICATION_XML));
+  }
+
+  @Test
+  void canWrite_withStringClassAndJsonMediaType_returnsTrue() {
+    assertTrue(converter.canWrite(ResolvableType.forClass(String.class), String.class, MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canWrite_withNonStringClass_returnsFalse() {
+    assertFalse(converter.canWrite(ResolvableType.forClass(Integer.class), Integer.class, MediaType.APPLICATION_JSON));
+  }
+
+  @Test
+  void canWrite_withNullMediaType_returnsTrue() {
+    assertTrue(converter.canWrite(ResolvableType.forClass(String.class), String.class, null));
+  }
+
+  @Test
+  void getSupportedMediaTypes_returnsJsonTextPlainAndAll() {
+    var types = converter.getSupportedMediaTypes();
+    assertEquals(3, types.size());
+    assertTrue(types.contains(MediaType.APPLICATION_JSON));
+    assertTrue(types.contains(MediaType.TEXT_PLAIN));
+    assertTrue(types.contains(MediaType.ALL));
+  }
+
+  @Test
+  void read_withUtf8Content_returnsExactString() throws IOException {
+    String json = "{\"key\":\"value\"}";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+
+  @Test
+  void read_withExplicitCharsetInContentType_usesSpecifiedCharset() throws IOException {
+    String json = "{\"key\":\"ñ\"}";
+    MediaType mediaType = new MediaType("application", "json", StandardCharsets.ISO_8859_1);
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(mediaType);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.ISO_8859_1)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+
+  @Test
+  void read_withNoContentType_defaultsToUtf8() throws IOException {
+    String json = "{\"key\":\"value\"}";
+    HttpHeaders headers = new HttpHeaders();
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+
+  @Test
+  void read_withEmptyBody_returnsEmptyString() throws IOException {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(new byte[0]));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals("", result);
+  }
+
+  @Test
+  void write_withUtf8ContentType_writesCorrectBytes() throws IOException {
+    String value = "{\"key\":\"value\"}";
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(outputMessage.getBody()).thenReturn(outputStream);
+
+    converter.write(value, ResolvableType.forClass(String.class), MediaType.APPLICATION_JSON, outputMessage, Map.of());
+
+    assertEquals(value, outputStream.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void write_withNullContentType_defaultsToUtf8() throws IOException {
+    String value = "{\"key\":\"value\"}";
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(outputMessage.getBody()).thenReturn(outputStream);
+
+    converter.write(value, ResolvableType.forClass(String.class), null, outputMessage, Map.of());
+
+    assertEquals(value, outputStream.toString(StandardCharsets.UTF_8));
+  }
+
+  @Test
+  void write_withExplicitCharset_usesSpecifiedCharset() throws IOException {
+    String value = "{\"key\":\"ñ\"}";
+    MediaType mediaType = new MediaType("application", "json", StandardCharsets.ISO_8859_1);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    when(outputMessage.getBody()).thenReturn(outputStream);
+
+    converter.write(value, ResolvableType.forClass(String.class), mediaType, outputMessage, Map.of());
+
+    assertEquals(value, outputStream.toString(StandardCharsets.ISO_8859_1));
+  }
+
+  @Test
+  void read_preservesJsonWhitespaceAndFormatting() throws IOException {
+    String json = "{\n  \"key\" : \"value\",\n  \"nested\" : { \"a\" : 1 }\n}";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(MediaType.APPLICATION_JSON);
+    when(inputMessage.getHeaders()).thenReturn(headers);
+    when(inputMessage.getBody()).thenReturn(new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8)));
+
+    String result = converter.read(ResolvableType.forClass(String.class), inputMessage, Map.of());
+
+    assertEquals(json, result);
+  }
+}
+

--- a/src/test/resources/wm/__files/circulation/checkin-response.json
+++ b/src/test/resources/wm/__files/circulation/checkin-response.json
@@ -1,0 +1,8 @@
+{
+  "item": {
+    "id": "9a326225-6530-41cc-9399-a61987bfab3c",
+    "barcode": "ABC-abc-1234"
+  },
+  "staffSlipContext": {}
+}
+

--- a/src/test/resources/wm/__files/circulation/checkout-response.json
+++ b/src/test/resources/wm/__files/circulation/checkout-response.json
@@ -1,0 +1,17 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "userId": "a7853dda-520b-4f7a-a1fb-9383665ea770",
+  "itemId": "4def31b0-2b60-4531-ad44-7eab60fa5428",
+  "status": {
+    "name": "Open"
+  },
+  "loanDate": "2025-01-01T00:00:00.000Z",
+  "dueDate": "2025-02-01T00:00:00.000Z",
+  "action": "checkedout",
+  "item": {
+    "id": "4def31b0-2b60-4531-ad44-7eab60fa5428",
+    "barcode": "DEF-def-5678",
+    "callNumber": "CN-001"
+  }
+}
+

--- a/src/test/resources/wm/__files/circulation/open-request-response.json
+++ b/src/test/resources/wm/__files/circulation/open-request-response.json
@@ -1,0 +1,14 @@
+{
+  "id": "ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a",
+  "requestType": "Page",
+  "status": "Open - Not yet filled",
+  "requestDate": "2017-07-29T22:25:37Z",
+  "requesterId": "ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a",
+  "itemId": "9a326225-6530-41cc-9399-a61987bfab3c",
+  "instanceId": "76834d5a-08e8-45ea-84ca-4d9b10aa341c",
+  "holdingsRecordId": "76834d5a-08e8-45ea-84ca-4d9b10aa342c",
+  "fulfillmentPreference": "Hold Shelf",
+  "requestExpirationDate": "2027-07-25T22:25:37Z",
+  "position": 1
+}
+


### PR DESCRIPTION
### Purpose
Fix following issues introduced after migration to Spring Boot 4.0.5 and found during regression testing:
- Request/Response DTOs are not properly (de)serialized for Inn-Reach clients methods
- Fix Request DTOs for POST methods of Folio clients
- fix retrieving page slips
- fix NEWS.md

### Approach
Perform troubleshooting utilizing the suggestions from AI/Copilot and address each found issue with a proper fix.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-577](https://folio-org.atlassian.net/browse/MODINREACH-577)