### PR TITLE
MODINREACH-577: Fix response DTO for checkInPatronHoldItem and checkInPatronHoldUnshippedItem

### DIFF
--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -60,6 +60,7 @@ import org.folio.innreach.domain.service.RetryableUpdateService;
 import org.folio.innreach.domain.service.VirtualRecordService;
 import org.folio.innreach.dto.CancelTransactionHoldDTO;
 import org.folio.innreach.dto.CheckInDTO;
+import org.folio.innreach.dto.CheckInResponseDTO;
 import org.folio.innreach.dto.InnReachTransactionDTO;
 import org.folio.innreach.dto.Item;
 import org.folio.innreach.dto.LoanStatus;
@@ -125,21 +126,27 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
     transaction.setState(ITEM_RECEIVED);
 
-    var response = checkInItem(transaction, servicePointId);
+    var checkInResponse = checkInItem(transaction, servicePointId);
 
     notifier.reportItemReceived(transaction);
 
     handleItemWithCanceledRequest(transaction);
 
-    log.info("checkInPatronHoldItem:: result: {}", response);
-    return response;
+    log.info("checkInPatronHoldItem:: Patron Hold Item is Checked-In");
+
+    var hold = (TransactionPatronHold) transaction.getHold();
+    return new PatronHoldCheckInResponseDTO()
+      .transaction(transactionMapper.toDTO(transaction))
+      .folioCheckIn(checkInResponse)
+      .barcodeAugmented(!hold.getShippedItemBarcode().equals(hold.getFolioItemBarcode()));
   }
 
   @Override
   public PatronHoldCheckInResponseDTO checkInPatronHoldUnshippedItem(UUID transactionId, UUID servicePointId, String itemBarcode) {
     log.debug("checkInPatronHoldUnshippedItem:: parameters transactionId: {}, servicePointId: {}", transactionId, servicePointId);
     var transaction = fetchTransactionById(transactionId);
-    var folioItemBarcode = transaction.getHold().getFolioItemBarcode();
+    var hold = (TransactionPatronHold) transaction.getHold();
+    var folioItemBarcode = hold.getFolioItemBarcode();
 
     verifyState(transaction, PATRON_HOLD, TRANSFER);
     Assert.isTrue(folioItemBarcode == null, "Item associated with the transaction has a barcode assigned");
@@ -148,14 +155,17 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
 
     transaction.setState(RECEIVE_UNANNOUNCED);
 
-    var response = checkInItem(transaction, servicePointId);
+    var checkInResponse = checkInItem(transaction, servicePointId);
 
     notifier.reportUnshippedItemReceived(transaction);
 
     handleItemWithCanceledRequest(transaction);
 
-    log.info("checkInPatronHoldUnshippedItem:: result: {}", response);
-    return response;
+    log.info("checkInPatronHoldUnshippedItem:: Patron Hold Unshipped Item is Checked-In");
+    return new PatronHoldCheckInResponseDTO()
+      .transaction(transactionMapper.toDTO(transaction))
+      .folioCheckIn(checkInResponse)
+      .barcodeAugmented(!hold.getShippedItemBarcode().equals(hold.getFolioItemBarcode()));
   }
 
   @Override
@@ -649,7 +659,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     }
   }
 
-  private PatronHoldCheckInResponseDTO checkInItem(InnReachTransaction transaction, UUID servicePointId) {
+  private CheckInResponseDTO checkInItem(InnReachTransaction transaction, UUID servicePointId) {
     log.debug("checkInItem:: parameters transaction: {}, servicePointId: {}", transaction, servicePointId);
     var hold = (TransactionPatronHold) transaction.getHold();
     var shippedItemBarcode = hold.getShippedItemBarcode();
@@ -658,12 +668,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
     Assert.isTrue(shippedItemBarcode != null, "shippedItemBarcode is not set");
     Assert.isTrue(folioItemBarcode != null, "folioItemBarcode is not set");
 
-    var checkInResponse = loanService.checkInItem(transaction, servicePointId);
-
-    return new PatronHoldCheckInResponseDTO()
-      .transaction(transactionMapper.toDTO(transaction))
-      .folioCheckIn(checkInResponse)
-      .barcodeAugmented(!shippedItemBarcode.equals(folioItemBarcode));
+    return loanService.checkInItem(transaction, servicePointId);
   }
 
   private void updateItemTransactionOnRequestChange(RequestDTO request, InnReachTransaction transaction) {

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerIT.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerIT.java
@@ -1,5 +1,8 @@
 package org.folio.innreach.controller;
 
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.ITEM_RECEIVED;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RECEIVE_UNANNOUNCED;
+import static org.folio.innreach.domain.entity.InnReachTransaction.TransactionState.RETURN_UNCIRCULATED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,8 +14,14 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
+import org.folio.innreach.domain.entity.InnReachTransaction;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import tools.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,10 +55,24 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
   private static final String GET_ALL_TRANSACTIONS_ENDPOINT = "/inn-reach/transactions";
   private static final String CHECK_IN_PATRON_HOLD_ENDPOINT =
     "/inn-reach/transactions/{id}/receive-item/{servicePointId}";
+  private static final String CHECK_IN_UNSHIPPED_ENDPOINT =
+    "/inn-reach/transactions/{id}/receive-unshipped-item/{servicePointId}/{itemBarcode}";
   private static final String CANCEL_ITEM_HOLD_ENDPOINT =
     "/inn-reach/transactions/{id}/itemhold/cancel";
   private static final String REMOVE_PATRON_HOLD_ENDPOINT =
     "/inn-reach/transactions/{id}/patronhold/remove";
+  private static final String RETURN_PATRON_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/patronhold/return-item/{servicePointId}";
+  private static final String TRANSFER_ITEM_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/itemhold/transfer-item/{itemId}";
+  private static final String CHECK_OUT_PATRON_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/patronhold/check-out-item/{servicePointId}";
+  private static final String CHECK_OUT_LOCAL_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/localhold/check-out-item/{servicePointId}";
+  private static final String FINAL_CHECKIN_ENDPOINT =
+    "/inn-reach/transactions/{id}/itemhold/finalcheckin/{servicePointId}";
+  private static final String CANCEL_LOCAL_HOLD_ENDPOINT =
+    "/inn-reach/transactions/{id}/localhold/cancel";
 
   private static final String PRE_POPULATED_ITEM_HOLD_ITEM_BARCODE = "DEF-def-5678";
   private static final String CHECK_OUT_BY_BARCODE_URL = "/circulation/check-out-by-barcode";
@@ -65,6 +88,17 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
 
   // Item/request IDs from pre-populated data
   private static final String PATRON_HOLD_REQUEST_ID = "ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a";
+  private static final String PATRON_HOLD_ITEM_ID = "9a326225-6530-41cc-9399-a61987bfab3c";
+  private static final String UNSHIPPED_ITEM_BARCODE = "newbarcode";
+
+  // Local hold data for testing
+  private static final String LOCAL_HOLD_TRANSACTION_ID = "79b0a1fb-55be-4e55-9d84-01303aaec1ce";
+  private static final String LOCAL_HOLD_REQUEST_ID = "4106d147-9085-4dfa-a59f-b8d50d551a48";
+  private static final String LOCAL_HOLD_INSTANCE_ID = "709c1075-0378-48af-a682-b4e7ac170424";
+  private static final String ITEM_HOLD_ITEM_ID = "4def31b0-2b60-4531-ad44-7eab60fa5428";
+  private static final String ITEM_HOLD_REQUEST_ID = "26278b3a-de32-4deb-b81b-896637b3dbeb";
+  private static final String ITEM_HOLD_LOAN_ID = "06e820e3-71a0-455e-8c73-3963aea677d4";
+  private static final String PATRON_HOLD_LOAN_ID = "fd5109c7-8934-4294-9504-c1a4a4f07c96";
 
   @MockitoBean
   private InnReachExternalService innReachExternalService;
@@ -168,16 +202,17 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
   }
 
   @SneakyThrows
-  @Test
+  @ParameterizedTest
+  @MethodSource("checkInItemPatronHoldTestArguments")
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/inn-reach-transaction/pre-populate-transaction-item-shipped.sql"
   })
-  void checkInPatronHoldItem_success() {
+  void checkInPatronHoldItem_success(InnReachTransaction.TransactionState expectedState, String requestStubResponse) {
     stubPost(CHECK_IN_BY_BARCODE_URL, "circulation/checkin-response.json");
 
     // Stub request lookup for handleItemWithCanceledRequest
-    stubGet("/circulation/requests/" + PATRON_HOLD_REQUEST_ID, "circulation/open-request-response.json");
+    stubGet("/circulation/requests/" + PATRON_HOLD_REQUEST_ID, requestStubResponse);
 
     when(innReachExternalService.postInnReachApi(any(), any(), any()))
       .thenReturn("ok");
@@ -188,7 +223,7 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
         .headers(getOkapiHeaders()))
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.transaction").exists())
-      .andExpect(jsonPath("$.transaction.state").value("ITEM_RECEIVED"))
+      .andExpect(jsonPath("$.transaction.state").value(expectedState.name()))
       .andExpect(jsonPath("$.folioCheckIn").exists());
   }
 
@@ -248,5 +283,170 @@ class InnReachTransactionControllerIT extends BaseApiControllerTest {
         .headers(getOkapiHeaders()))
       .andExpect(status().isNotFound());
   }
-}
 
+  @SneakyThrows
+  @ParameterizedTest
+  @MethodSource("checkInUnshippedTestArguments")
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-patron-hold-unshipped.sql"
+  })
+  void checkInPatronHoldUnshippedItem_success(InnReachTransaction.TransactionState expectedState, String requestStubResponse) {
+    // Stub barcode lookup - no existing item with this barcode
+    stubGet("/inventory/items", "inventory/empty-items-response.json",
+      Map.of("query", "barcode==" + UNSHIPPED_ITEM_BARCODE));
+
+    // Stub item find and update for addItemBarcode
+    stubGet("/inventory/items/" + PATRON_HOLD_ITEM_ID, "inventory/item-response.json");
+    stubPut("/inventory/items/" + PATRON_HOLD_ITEM_ID);
+
+    // Stub check-in
+    stubPost(CHECK_IN_BY_BARCODE_URL, "circulation/checkin-response.json");
+
+    // Stub request lookup for handleItemWithCanceledRequest
+    stubGet("/circulation/requests/" + PATRON_HOLD_REQUEST_ID, requestStubResponse);
+
+    when(innReachExternalService.postInnReachApi(any(), any(), any()))
+      .thenReturn("ok");
+
+    mockMvc.perform(post(CHECK_IN_UNSHIPPED_ENDPOINT,
+        PATRON_HOLD_TRANSACTION_ID, SERVICE_POINT_ID, UNSHIPPED_ITEM_BARCODE)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.transaction").exists())
+      .andExpect(jsonPath("$.transaction.state").value(expectedState.name()))
+      .andExpect(jsonPath("$.folioCheckIn").exists());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-patron-hold-item-received.sql"
+  })
+  void returnPatronHoldItem_withOpenLoan_success() {
+    stubGet("/circulation/loans/" + PATRON_HOLD_LOAN_ID, "circulation/open-loan-response.json");
+    stubPost(CHECK_IN_BY_BARCODE_URL, "circulation/checkin-response.json");
+
+    mockMvc.perform(post(RETURN_PATRON_HOLD_ENDPOINT,
+        PATRON_HOLD_TRANSACTION_ID, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isNoContent());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void transferItemHold_sameItemAsRequest_success() {
+    stubGet("/circulation/requests/" + ITEM_HOLD_REQUEST_ID, "circulation/item-hold-request-response.json");
+    stubGet("/inventory/items/" + ITEM_HOLD_ITEM_ID, "inventory/item-hold-item-response.json");
+
+    when(innReachExternalService.postInnReachApi(any(), any(), any()))
+      .thenReturn("ok");
+
+    mockMvc.perform(post(TRANSFER_ITEM_HOLD_ENDPOINT,
+        ITEM_HOLD_TRANSACTION_ID, ITEM_HOLD_ITEM_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isNoContent());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-patron-hold-item-received.sql"
+  })
+  void checkOutPatronHoldItem_success() {
+    stubGet("/circulation/loans", "circulation/empty-loans-response.json", Map.of());
+    stubPost(CHECK_OUT_BY_BARCODE_URL, "circulation/checkout-response.json");
+
+    mockMvc.perform(post(CHECK_OUT_PATRON_HOLD_ENDPOINT,
+        PATRON_HOLD_TRANSACTION_ID, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.folioCheckOut").exists())
+      .andExpect(jsonPath("$.transaction").exists());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void checkOutLocalHoldItem_success() {
+    stubGet("/circulation/loans", "circulation/empty-loans-response.json", Map.of());
+    stubPost(CHECK_OUT_BY_BARCODE_URL, "circulation/checkout-response.json");
+
+    mockMvc.perform(post(CHECK_OUT_LOCAL_HOLD_ENDPOINT,
+        LOCAL_HOLD_TRANSACTION_ID, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.folioCheckOut").exists())
+      .andExpect(jsonPath("$.transaction").exists());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-item-hold-shipped.sql"
+  })
+  void finalCheckInItemHold_withOpenLoan_success() {
+    stubGet("/circulation/loans/" + ITEM_HOLD_LOAN_ID, "circulation/item-hold-open-loan-response.json");
+    stubPost(CHECK_IN_BY_BARCODE_URL, "circulation/checkin-response.json");
+
+    when(innReachExternalService.postInnReachApi(any(), any(), any()))
+      .thenReturn("ok");
+
+    mockMvc.perform(post(FINAL_CHECKIN_ENDPOINT,
+        ITEM_HOLD_TRANSACTION_ID, SERVICE_POINT_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isNoContent());
+  }
+
+  @SneakyThrows
+  @Test
+  @Sql(scripts = {
+    "classpath:db/central-server/pre-populate-central-server.sql",
+    "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
+  })
+  void cancelLocalHold_success() {
+    stubGet("/circulation/requests/" + LOCAL_HOLD_REQUEST_ID, "circulation/local-hold-open-request-response.json");
+    stubPut("/circulation/requests/" + LOCAL_HOLD_REQUEST_ID);
+    stubGet("/inventory/instances/" + LOCAL_HOLD_INSTANCE_ID, "inventory/instance-response.json");
+
+    when(innReachExternalService.postInnReachApi(any(), any(), any()))
+      .thenReturn("ok");
+
+    mockMvc.perform(post(CANCEL_LOCAL_HOLD_ENDPOINT, LOCAL_HOLD_TRANSACTION_ID)
+        .contentType(MediaType.APPLICATION_JSON)
+        .content("{\"cancellationReasonId\":\"75187e8d-e25a-47a7-89ad-23ba612bb5aa\"}")
+        .headers(getOkapiHeaders()))
+      .andExpect(status().isOk())
+      .andExpect(jsonPath("$.state").value("CANCEL_REQUEST"));
+  }
+
+  private static Stream<Arguments> checkInItemPatronHoldTestArguments() {
+    return Stream.of(
+      Arguments.of(ITEM_RECEIVED, "circulation/open-request-response.json"),
+      Arguments.of(RETURN_UNCIRCULATED, "circulation/canceled-request-response.json")
+    );
+  }
+
+  private static Stream<Arguments> checkInUnshippedTestArguments() {
+    return Stream.of(
+      Arguments.of(RECEIVE_UNANNOUNCED, "circulation/open-request-response.json"),
+      Arguments.of(RETURN_UNCIRCULATED, "circulation/canceled-request-response.json")
+    );
+  }
+}

--- a/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/InnReachTransactionControllerTest.java
@@ -1218,6 +1218,7 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
 
     var transaction = response.getTransaction();
     assertEquals(PRE_POPULATED_ITEM_SHIPPED_TRANSACTION_ID, transaction.getId());
+    assertEquals(TransactionStateEnum.ITEM_RECEIVED, transaction.getState());
 
     var checkInResponse = response.getFolioCheckIn();
     assertEquals(PRE_POPULATED_PATRON_HOLD_ITEM_BARCODE, checkInResponse.getItem().getBarcode());
@@ -1252,6 +1253,7 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
 
     var transaction = response.getTransaction();
     assertEquals(PRE_POPULATED_ITEM_SHIPPED_TRANSACTION_ID, transaction.getId());
+    assertEquals(TransactionStateEnum.RETURN_UNCIRCULATED, transaction.getState());
 
     var checkInResponse = response.getFolioCheckIn();
     assertEquals(PRE_POPULATED_PATRON_HOLD_ITEM_BARCODE, checkInResponse.getItem().getBarcode());
@@ -1911,8 +1913,8 @@ class InnReachTransactionControllerTest extends BaseControllerTest {
   void cancelPatronHold_when_TransactionIsOnHoldOrTransfer_and_RequestIsClosed_withNoVirtualRecord(TransactionState state) {
     mockFindRequest(PRE_POPULATED_PATRON_HOLD_REQUEST_ID, CLOSED_CANCELLED);
 
-    modifyTransactionState(PRE_POPULATED_PATRON_HOLD_TRANSACTION_ID, state);
     modifyTransaction(PRE_POPULATED_PATRON_HOLD_TRANSACTION_ID, t -> {
+      t.setState(state);
       t.getHold().setFolioItemId(null);
       t.getHold().setFolioHoldingId(null);
       t.getHold().setFolioInstanceId(null);

--- a/src/test/resources/db/inn-reach-transaction/pre-populate-item-hold-shipped.sql
+++ b/src/test/resources/db/inn-reach-transaction/pre-populate-item-hold-shipped.sql
@@ -1,0 +1,19 @@
+-- Item hold transaction in ITEM_SHIPPED state (state=10)
+INSERT INTO transaction_pickup_location (id, pickup_loc_code, print_name, delivery_stop) VALUES
+('956214e2-6397-49ed-817b-70cc03089951', 'pickupLocCode2', 'printName2', 'deliveryStop2');
+
+INSERT INTO transaction_hold (id, transaction_time, pickup_location_id, patron_id, patron_agency_code, item_agency_code, item_id,
+central_item_type, need_before, title, author, folio_patron_id, folio_item_id, due_date_time, folio_request_id, folio_loan_id,
+folio_item_barcode, folio_patron_barcode, folio_instance_id, folio_holding_id, central_patron_type, patron_name) VALUES
+('891bfff3-ba79-4beb-8c25-f714f14c6a31', 1632039760, '956214e2-6397-49ed-817b-70cc03089951',
+ 'u6ct3wssbnhxvip3sobwmxvhoa', 'qwe56', 'asd78', 'item2', 2, extract(epoch from current_timestamp), 'title2', 'author2',
+ 'a7853dda-520b-4f7a-a1fb-9383665ea770', '4def31b0-2b60-4531-ad44-7eab60fa5428', '1640091901',
+ '26278b3a-de32-4deb-b81b-896637b3dbeb', '06e820e3-71a0-455e-8c73-3963aea677d4', 'DEF-def-5678', '000002',
+ '891bfff3-ba79-4beb-8c25-f714f14c6a32', '891bfff3-ba79-4beb-8c25-f714f14c6a33', 1, 'patronName2');
+
+INSERT INTO transaction_item_hold (id) VALUES
+('891bfff3-ba79-4beb-8c25-f714f14c6a31');
+
+INSERT INTO inn_reach_transaction (id, tracking_id, central_server_code, state, type, transaction_hold_id) VALUES
+('ab2393a1-acc4-4849-82ac-8cc0c37339e1', 'tracking2', 'd2ir', 10, 0, '891bfff3-ba79-4beb-8c25-f714f14c6a31');
+

--- a/src/test/resources/db/inn-reach-transaction/pre-populate-patron-hold-item-received.sql
+++ b/src/test/resources/db/inn-reach-transaction/pre-populate-patron-hold-item-received.sql
@@ -1,0 +1,19 @@
+-- Patron hold transaction in ITEM_RECEIVED state (state=9) with loan
+INSERT INTO transaction_pickup_location (id, pickup_loc_code, print_name, delivery_stop) VALUES
+('809adcde-3e67-4822-9916-fd653a681358', 'pickupLocCode1', 'printName1', 'deliveryStop1');
+
+INSERT INTO transaction_hold (id, transaction_time, pickup_location_id, patron_id, patron_agency_code, item_agency_code, item_id,
+central_item_type, need_before, title, author, folio_patron_id, folio_item_id, due_date_time, folio_request_id, folio_loan_id,
+folio_item_barcode, folio_patron_barcode, folio_instance_id, folio_holding_id, central_patron_type, patron_name) VALUES
+('76834d5a-08e8-45ea-84ca-4d9b10aa340c', extract(epoch from current_timestamp), '809adcde-3e67-4822-9916-fd653a681358',
+ 'ifkkmbcnljgy5elaav74pnxgxa', 'qwe12', 'asd34', 'item1', 1, extract(epoch from current_timestamp), 'title1', 'author1',
+ '4154a604-4d5a-4d8e-9160-057fc7b6e6b8', '9a326225-6530-41cc-9399-a61987bfab3c', '1640091801',
+ 'ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a', 'fd5109c7-8934-4294-9504-c1a4a4f07c96', 'ABC-abc-1234', '000001',
+ '76834d5a-08e8-45ea-84ca-4d9b10aa341c', '76834d5a-08e8-45ea-84ca-4d9b10aa342c', 2, 'patronName1');
+
+INSERT INTO transaction_patron_hold (id, call_number, shipped_item_barcode) VALUES
+('76834d5a-08e8-45ea-84ca-4d9b10aa340c', '0123456789', 'ABC-abc-1234');
+
+INSERT INTO inn_reach_transaction (id, tracking_id, central_server_code, state, type, transaction_hold_id) VALUES
+('0aab1720-14b4-4210-9a19-0d0bf1cd64d3', 'tracking1', 'd2ir', 9, 1, '76834d5a-08e8-45ea-84ca-4d9b10aa340c');
+

--- a/src/test/resources/db/inn-reach-transaction/pre-populate-patron-hold-unshipped.sql
+++ b/src/test/resources/db/inn-reach-transaction/pre-populate-patron-hold-unshipped.sql
@@ -1,0 +1,18 @@
+INSERT INTO transaction_pickup_location (id, pickup_loc_code, print_name, delivery_stop) VALUES
+('809adcde-3e67-4822-9916-fd653a681358', 'pickupLocCode1', 'printName1', 'deliveryStop1');
+
+INSERT INTO transaction_hold (id, transaction_time, pickup_location_id, patron_id, patron_agency_code, item_agency_code, item_id,
+central_item_type, need_before, title, author, folio_patron_id, folio_item_id, due_date_time, folio_request_id, folio_loan_id,
+folio_item_barcode, folio_patron_barcode, folio_instance_id, folio_holding_id, central_patron_type, patron_name) VALUES
+('76834d5a-08e8-45ea-84ca-4d9b10aa340c', extract(epoch from current_timestamp), '809adcde-3e67-4822-9916-fd653a681358',
+ 'ifkkmbcnljgy5elaav74pnxgxa', 'qwe12', 'asd34', 'item1', 1, extract(epoch from current_timestamp), 'title1', 'author1',
+ '4154a604-4d5a-4d8e-9160-057fc7b6e6b8', '9a326225-6530-41cc-9399-a61987bfab3c', null,
+ 'ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a', null, null, '000001',
+ '76834d5a-08e8-45ea-84ca-4d9b10aa341c', '76834d5a-08e8-45ea-84ca-4d9b10aa342c', 2, 'patronName1');
+
+INSERT INTO transaction_patron_hold (id) VALUES
+('76834d5a-08e8-45ea-84ca-4d9b10aa340c');
+
+INSERT INTO inn_reach_transaction (id, tracking_id, central_server_code, state, type, transaction_hold_id) VALUES
+('0aab1720-14b4-4210-9a19-0d0bf1cd64d3', 'tracking1', 'd2ir', 1, 1, '76834d5a-08e8-45ea-84ca-4d9b10aa340c');
+

--- a/src/test/resources/wm/__files/circulation/canceled-request-response.json
+++ b/src/test/resources/wm/__files/circulation/canceled-request-response.json
@@ -1,0 +1,14 @@
+{
+  "id": "ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a",
+  "requestType": "Page",
+  "status": "Closed - Cancelled",
+  "requestDate": "2017-07-29T22:25:37Z",
+  "requesterId": "ea11eba7-3c0f-4d15-9cca-c8608cd6bc8a",
+  "itemId": "9a326225-6530-41cc-9399-a61987bfab3c",
+  "instanceId": "76834d5a-08e8-45ea-84ca-4d9b10aa341c",
+  "holdingsRecordId": "76834d5a-08e8-45ea-84ca-4d9b10aa342c",
+  "fulfillmentPreference": "Hold Shelf",
+  "requestExpirationDate": "2027-07-25T22:25:37Z",
+  "position": 1
+}
+

--- a/src/test/resources/wm/__files/circulation/empty-loans-response.json
+++ b/src/test/resources/wm/__files/circulation/empty-loans-response.json
@@ -1,0 +1,5 @@
+{
+  "loans": [],
+  "totalRecords": 0
+}
+

--- a/src/test/resources/wm/__files/circulation/item-hold-open-loan-response.json
+++ b/src/test/resources/wm/__files/circulation/item-hold-open-loan-response.json
@@ -1,0 +1,12 @@
+{
+  "id": "06e820e3-71a0-455e-8c73-3963aea677d4",
+  "userId": "a7853dda-520b-4f7a-a1fb-9383665ea770",
+  "itemId": "4def31b0-2b60-4531-ad44-7eab60fa5428",
+  "status": {
+    "name": "Open"
+  },
+  "loanDate": "2025-01-01T00:00:00.000Z",
+  "dueDate": "2025-02-01T00:00:00.000Z",
+  "action": "checkedout"
+}
+

--- a/src/test/resources/wm/__files/circulation/item-hold-request-response.json
+++ b/src/test/resources/wm/__files/circulation/item-hold-request-response.json
@@ -1,0 +1,14 @@
+{
+  "id": "26278b3a-de32-4deb-b81b-896637b3dbeb",
+  "requestType": "Page",
+  "status": "Open - Not yet filled",
+  "requestDate": "2017-07-29T22:25:37Z",
+  "requesterId": "a7853dda-520b-4f7a-a1fb-9383665ea770",
+  "itemId": "4def31b0-2b60-4531-ad44-7eab60fa5428",
+  "instanceId": "891bfff3-ba79-4beb-8c25-f714f14c6a32",
+  "holdingsRecordId": "891bfff3-ba79-4beb-8c25-f714f14c6a33",
+  "fulfillmentPreference": "Hold Shelf",
+  "requestExpirationDate": "2027-07-25T22:25:37Z",
+  "position": 1
+}
+

--- a/src/test/resources/wm/__files/circulation/local-hold-open-request-response.json
+++ b/src/test/resources/wm/__files/circulation/local-hold-open-request-response.json
@@ -1,0 +1,14 @@
+{
+  "id": "4106d147-9085-4dfa-a59f-b8d50d551a48",
+  "requestType": "Page",
+  "status": "Open - Not yet filled",
+  "requestDate": "2017-07-29T22:25:37Z",
+  "requesterId": "a8ffe3cb-f682-499d-893b-47ff9efb3803",
+  "itemId": "c633da85-8112-4453-af9c-c250e417179d",
+  "instanceId": "709c1075-0378-48af-a682-b4e7ac170424",
+  "holdingsRecordId": "709c1075-0378-48af-a682-b4e7ac170425",
+  "fulfillmentPreference": "Hold Shelf",
+  "requestExpirationDate": "2027-07-25T22:25:37Z",
+  "position": 1
+}
+

--- a/src/test/resources/wm/__files/circulation/open-loan-response.json
+++ b/src/test/resources/wm/__files/circulation/open-loan-response.json
@@ -1,0 +1,12 @@
+{
+  "id": "fd5109c7-8934-4294-9504-c1a4a4f07c96",
+  "userId": "4154a604-4d5a-4d8e-9160-057fc7b6e6b8",
+  "itemId": "9a326225-6530-41cc-9399-a61987bfab3c",
+  "status": {
+    "name": "Open"
+  },
+  "loanDate": "2025-01-01T00:00:00.000Z",
+  "dueDate": "2025-02-01T00:00:00.000Z",
+  "action": "checkedout"
+}
+

--- a/src/test/resources/wm/__files/inventory/empty-items-response.json
+++ b/src/test/resources/wm/__files/inventory/empty-items-response.json
@@ -1,0 +1,5 @@
+{
+  "items": [],
+  "totalRecords": 0
+}
+

--- a/src/test/resources/wm/__files/inventory/item-hold-item-response.json
+++ b/src/test/resources/wm/__files/inventory/item-hold-item-response.json
@@ -1,0 +1,24 @@
+{
+  "id": "4def31b0-2b60-4531-ad44-7eab60fa5428",
+  "_version": "1",
+  "status": {
+    "name": "Available"
+  },
+  "title": "Item hold test",
+  "hrid": "it00000000002",
+  "barcode": "DEF-def-5678",
+  "holdingsRecordId": "891bfff3-ba79-4beb-8c25-f714f14c6a33",
+  "materialType": {
+    "id": "5ee11d91-f7e8-481d-b079-65d708582ccc",
+    "name": "dvd"
+  },
+  "permanentLoanType": {
+    "id": "f7171bd3-cd3e-44ea-b2dd-74e29884690a",
+    "name": "newLoanType 1"
+  },
+  "effectiveLocation": {
+    "id": "ae5032a1-fe55-41d1-ab29-b7696b3312a4",
+    "name": "Big Circ"
+  }
+}
+


### PR DESCRIPTION
### Purpose
- Fix setting transaction state in response for ```POST /transactions/{id}/receive-item/{servicePointId}``` and ```POST /transactions/{id}/receive-unshipped-item/{servicePointId}/{itemBarcode}```
- add more integration tests with wiremock stubs

### Approach
- build response DTO after doing all operations with transaction

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-577](https://folio-org.atlassian.net/browse/MODINREACH-577)
