### PR TITLE
MODINREACH-572: Remove Item contribution logic from Circulation events handlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 * Fix issues found after migration to Spring Boot v4.0.5 ([MODINREACH-577](https://folio-org.atlassian.net/browse/MODINREACH-577))
 * Fix handling time-out errors from central server during ongoing contribution ([MODINREACH-581](https://folio-org.atlassian.net/browse/MODINREACH-581))
 * Fix redundant and overly verbose logging statements ([MODINREACH-583](https://folio-org.atlassian.net/browse/MODINREACH-583))
+* Remove Item Contribution logic from Circulation (loan and request) events handlers ([MODINREACH-572](https://folio-org.atlassian.net/browse/MODINREACH-572))
 
 ## v4.0.0 2026-04-17
 

--- a/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
@@ -180,20 +180,21 @@ public class ContributionJobRunner {
     boolean contributedInstance = isContributed(centralServerId, instance);
     log.info("runOngoingInstanceContribution:: eligibleInstance: {}, contributedInstance: {}", eligibleInstance, contributedInstance);
     if (!eligibleInstance && !contributedInstance) {
-      log.info("runOngoingInstanceContribution:: {}, instance id : {}", SKIPPING_INELIGIBLE_INSTANCE_MSG, instance.getId());
+      log.info("runOngoingInstanceContribution:: {}: {}", SKIPPING_INELIGIBLE_INSTANCE_MSG, instance.getId());
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_INSTANCE_MSG, FAILED);
       return;
     }
     if (eligibleInstance) {
-      log.info("runOngoingInstanceContribution:: contributing instance id: {}", instance.getId());
+      log.info("runOngoingInstanceContribution:: contributing instance: {}", instance.getId());
       recordContributionService.contributeInstance(centralServerId, instance);
       if (!contributedInstance) {
-        log.info("runOngoingInstanceContribution:: contributing items of new instance id: {}", instance.getId());
+        log.info("runOngoingInstanceContribution:: contributing items of new instance: {}", instance.getId());
         contributeOngoingItems(centralServerId, instance);
       }
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
-    } else if (contributedInstance) {
-      log.info("runOngoingInstanceContribution:: {}, instance id : {}", DE_CONTRIBUTE_INSTANCE_MSG, instance.getId());
+    } else {
+      // instance is already contributed (as contributedInstance == true), so de-contribute instance as it's not eligible
+      log.info("runOngoingInstanceContribution:: {}: {}", DE_CONTRIBUTE_INSTANCE_MSG, instance.getId());
       recordContributionService.deContributeInstance(centralServerId, instance);
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, DE_CONTRIBUTED);
     }
@@ -201,10 +202,12 @@ public class ContributionJobRunner {
 
   public void runOngoingInstanceDeContribution(UUID centralServerId, Instance deletedInstance, OngoingContributionStatus ongoingContributionStatus) {
     if (!isContributed(centralServerId, deletedInstance)) {
-      log.info("runOngoingInstanceDeContribution:: Skipping non-contributed instance, centralServer id: {}, instance id: {}", centralServerId, deletedInstance.getId());
+      log.info("runOngoingInstanceDeContribution:: Skipping non-contributed instance: {}, centralServer: {}",  deletedInstance.getId(), centralServerId);
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_MSG, FAILED);
       return;
     }
+
+    log.info("runOngoingInstanceDeContribution:: de-contributing instance: {}", deletedInstance.getId());
     recordContributionService.deContributeInstance(centralServerId, deletedInstance);
     ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, DE_CONTRIBUTED);
   }
@@ -212,29 +215,30 @@ public class ContributionJobRunner {
   public void runItemContribution(UUID centralServerId, Instance instance, Item item, OngoingContributionStatus ongoingContributionStatus) {
     boolean eligibleItem = isEligibleForContribution(centralServerId, item);
     boolean contributedItem = isContributed(centralServerId, instance, item);
-    log.info("runItemContribution:: eligibleItem: {}, contributedItem: {}", eligibleItem, contributedItem);
+    log.info("runItemContribution:: centralServer: {}, eligibleItem: {}, contributedItem: {}", centralServerId, eligibleItem, contributedItem);
     if (!eligibleItem && !contributedItem) {
-      log.info("runItemContribution:: skipping ineligible and non-contributed centralServer id: {}, item id: {}, instance id : {}", centralServerId, item.getId(), instance.getId());
+      log.info("runItemContribution:: skipping ineligible and non-contributed item: {}, for instance: {}", item.getId(), instance.getId());
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_MSG, FAILED);
       return;
     }
     if (isEligibleForContribution(centralServerId, instance)) {
-      log.info("runItemContribution:: Re-contributing instance to update bib status, centralServer id: {}, instance id : {}, item id: {}", centralServerId, instance.getId(), item.getId());
+      log.info("runItemContribution:: re-contributing instance {} to update bib status", instance.getId());
       recordContributionService.contributeInstance(centralServerId, instance);
       if (eligibleItem) {
-        log.info("runItemContribution:: contributing centralServer id: {}, instance id : {}, item id: {}", centralServerId, instance.getId(), item.getId());
+        log.info("runItemContribution:: contributing item: {}", item.getId());
         recordContributionService.contributeItems(centralServerId, instance.getHrid(), List.of(item));
-      } else if (contributedItem) {
-        log.info("runItemContribution:: de-contributing centralServer id: {}, instance id : {}, item id: {}", centralServerId, instance.getId(), item.getId());
+      } else {
+        // item is already contributed (as contributedItem == true), so de-contribute item as it's not eligible
+        log.info("runItemContribution:: de-contributing item: {}", item.getId());
         recordContributionService.deContributeItem(centralServerId, item);
       }
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
     } else if (contributedItem) {
-      log.info("runItemContribution:: {}, centralServer id: {}, instance id : {}, item id: {}", DE_CONTRIBUTE_INSTANCE_MSG, centralServerId, instance.getId(), item.getId());
+      log.info("runItemContribution:: {}: {}", DE_CONTRIBUTE_INSTANCE_MSG, instance.getId());
       recordContributionService.deContributeInstance(centralServerId, instance);
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, DE_CONTRIBUTED);
     } else {
-      log.info("runItemContribution:: {}, centralServer id: {}, instance id : {}, item id: {}", SKIPPING_INELIGIBLE_INSTANCE_ITEM_MSG, centralServerId, instance.getId(), item.getId());
+      log.info("runItemContribution:: {}, instance: {}, item: {}", SKIPPING_INELIGIBLE_INSTANCE_ITEM_MSG, instance.getId(), item.getId());
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_INSTANCE_ITEM_MSG, FAILED);
     }
   }
@@ -244,7 +248,7 @@ public class ContributionJobRunner {
     boolean contributedItem = isContributed(centralServerId, oldInstance, item);
     log.info("runItemMove:: eligibleItem: {}, contributedItem: {}", eligibleItem, contributedItem);
     if (!eligibleItem && !contributedItem) {
-      log.info("runItemMove:: Skipping ineligible and non-contributed item id: {}, new instance id: {}, old instance id: {}", item.getId(), newInstance.getId(), oldInstance.getId());
+      log.info("runItemMove:: Skipping ineligible and non-contributed item: {}, for new instance: {} and old instance: {}", item.getId(), newInstance.getId(), oldInstance.getId());
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_MSG, FAILED);
       return;
     }
@@ -252,23 +256,23 @@ public class ContributionJobRunner {
     // de-contribute item and update old instance
     if (contributedItem) {
       if (isEligibleForContribution(centralServerId, oldInstance)) {
-        log.info("runItemMove:: de-contributing item : {} from old instance id : {}", item.getId(), oldInstance.getId());
+        log.info("runItemMove:: de-contributing item : {} from old instance: {}", item.getId(), oldInstance.getId());
         recordContributionService.deContributeItem(centralServerId, item);
-        log.info("runItemMove:: re-contributing old instance id:{} to update bib status, item id; {}", oldInstance.getId(), item.getId());
+        log.info("runItemMove:: re-contributing old instance: {} to update bib status", oldInstance.getId());
         recordContributionService.contributeInstance(centralServerId, oldInstance);
       } else {
-        log.info("runItemMove:: e-contributing old instance id: {}, item id: {}", oldInstance.getId(), item.getId());
+        log.info("runItemMove:: de-contributing old instance: {}", oldInstance.getId());
         recordContributionService.deContributeInstance(centralServerId, oldInstance);
       }
     }
 
     // contribute item to a new instance
     if (isEligibleForContribution(centralServerId, newInstance)) {
-      log.info("runItemMove:: re-contributing new instance id: {} to update bib status, item id: {}", newInstance.getId(), item.getId());
+      log.info("runItemMove:: re-contributing new instance: {} to update bib status", newInstance.getId());
       recordContributionService.contributeInstance(centralServerId, newInstance);
 
       if (eligibleItem) {
-        log.info("runItemMove:: Contributing item to new instance id: {}, item id: {}", newInstance.getId(), item.getId());
+        log.info("runItemMove:: Contributing item {} to new instance: {}", item.getId(), newInstance.getId());
         recordContributionService.contributeItems(centralServerId, newInstance.getHrid(), List.of(item));
       }
     }
@@ -277,23 +281,20 @@ public class ContributionJobRunner {
 
   public void runItemDeContribution(UUID centralServerId, Instance instance, Item deletedItem, OngoingContributionStatus ongoingContributionStatus) {
     if (!isContributed(centralServerId, instance, deletedItem)) {
-      log.info("runItemDeContribution:: Skipping non-contributed item id: {}, instance id: {}", deletedItem.getId(), instance.getId());
+      log.info("runItemDeContribution:: Skipping non-contributed item: {}, for instance: {}, centralServer: {},", deletedItem.getId(), instance.getId(), centralServerId);
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, SKIPPING_INELIGIBLE_MSG, FAILED);
       return;
     }
 
     if (isEligibleForContribution(centralServerId, instance)) {
-      log.info("runItemDeContribution:: de-contributing centralServer id: {}, item id: {}, instance id: {}",
-        centralServerId, deletedItem.getId(), instance.getId());
+      log.info("runItemDeContribution:: de-contributing item: {} for instance: {}", deletedItem.getId(), instance.getId());
       recordContributionService.deContributeItem(centralServerId, deletedItem);
 
-      log.info("runItemDeContribution:: re-contributing instance to update bib status centralServer id: {}, item id: {}, instance id: {}",
-        centralServerId, deletedItem.getId(), instance.getId());
+      log.info("runItemDeContribution:: re-contributing instance: {} to update bib status", instance.getId());
       recordContributionService.contributeInstance(centralServerId, instance);
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
     } else {
-      log.info("runItemDeContribution:: {}, centralServer id: {}, item id: {}, instance id : {}",
-        DE_CONTRIBUTE_INSTANCE_MSG, centralServerId, deletedItem.getId(), instance.getId());
+      log.info("runItemDeContribution:: {}: {}", DE_CONTRIBUTE_INSTANCE_MSG, instance.getId());
       recordContributionService.deContributeInstance(centralServerId, instance);
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, DE_CONTRIBUTED);
     }
@@ -310,17 +311,14 @@ public class ContributionJobRunner {
   }
 
   private boolean isContributed(UUID centralServerId, Instance instance) {
-    log.info("isContributed:: parameters centralServerId: {}, instance id: {}", centralServerId, instance.getId());
     return recordContributionService.isContributed(centralServerId, instance);
   }
 
   private boolean isEligibleForContribution(UUID centralServerId, Item item) {
-    log.info("isEligibleForContribution:: parameters centralServerId: {}, item id: {}", centralServerId, item.getId());
     return validationService.isEligibleForContribution(centralServerId, item);
   }
 
   private boolean isContributed(UUID centralServerId, Instance instance, Item item) {
-    log.info("isContributed:: parameters centralServerId: {}, instance id: {}, item id: {}", centralServerId, instance.getId(), item.getId());
     return recordContributionService.isContributed(centralServerId, instance, item);
   }
 

--- a/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/ContributionJobRunner.java
@@ -20,7 +20,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.BiConsumer;
 import java.util.stream.StreamSupport;
 
 import com.google.common.collect.Iterables;
@@ -32,7 +31,6 @@ import org.folio.innreach.external.exception.InnReachConnectionException;
 import org.folio.innreach.external.exception.InnReachContributionRequestException;
 import org.folio.innreach.external.exception.ServiceSuspendedException;
 import org.folio.innreach.batch.contribution.InitialContributionJobConsumerContainer;
-import org.folio.innreach.external.exception.InnReachTimeOutException;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.stereotype.Service;
@@ -50,7 +48,6 @@ import org.folio.innreach.domain.service.InventoryViewService;
 import org.folio.innreach.domain.service.RecordContributionService;
 import org.folio.innreach.dto.Instance;
 import org.folio.innreach.dto.Item;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 
@@ -69,7 +66,6 @@ public class ContributionJobRunner {
   private final InventoryViewService inventoryViewService;
   private final ContributionJobProperties jobProperties;
   private final ContributionService contributionService;
-  private final FolioExecutionContext folioContext;
   @Qualifier("contributionRetryTemplate")
   private final RetryTemplate retryTemplate;
   private final IterationEventReaderFactory itemReaderFactory;
@@ -211,36 +207,6 @@ public class ContributionJobRunner {
     }
     recordContributionService.deContributeInstance(centralServerId, deletedInstance);
     ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, DE_CONTRIBUTED);
-  }
-
-  public void runItemContribution(UUID centralServerId, Instance instance, Item item) {
-    boolean eligibleItem = isEligibleForContribution(centralServerId, item);
-    boolean contributedItem = isContributed(centralServerId, instance, item);
-    log.info("Ongoing: eligibleItem: {}, contributedItem: {}", eligibleItem, contributedItem);
-    if (!eligibleItem && !contributedItem) {
-      log.info("Ongoing: skipping ineligible and non-contributed centralServer id: {}, item id: {}, instance id : {}", centralServerId, item.getId(), instance.getId());
-      return;
-    }
-
-    runOngoing(centralServerId, (ctx, statistics) -> {
-      log.info("Starting ongoing centralServer id: {}, item id: {} contribution job {}, instance id : {}", centralServerId, item.getId(), ctx, instance.getId());
-
-      if (isEligibleForContribution(centralServerId, instance)) {
-        log.info("Ongoing: Re-contributing instance to update bib status, centralServer id: {}, instance id : {}, item id: {}", centralServerId, instance.getId(), item.getId());
-        contributeInstance(centralServerId, instance, statistics);
-
-        if (eligibleItem) {
-          log.info("Ongoing: contributing centralServer id:{}, instance id : {}, item id: {}", centralServerId, instance.getId(), item.getId());
-          contributeItemsChunk(centralServerId, instance.getHrid(), List.of(item), statistics);
-        } else if (contributedItem) {
-          log.info("Ongoing: de-contributing centralServer id: {}, instance id : {}, item id: {}", centralServerId, instance.getId(), item.getId());
-          deContributeItem(centralServerId, item, statistics);
-        }
-      } else if (contributedItem) {
-        log.info(" Ongoing: {}, centralServer id: {}, instance id : {}, item id: {}", DE_CONTRIBUTE_INSTANCE_MSG, centralServerId, instance.getId(), item.getId());
-        deContributeInstance(centralServerId, instance, statistics);
-      }
-    });
   }
 
   public void runItemContribution(UUID centralServerId, Instance instance, Item item, OngoingContributionStatus ongoingContributionStatus) {
@@ -458,51 +424,6 @@ public class ContributionJobRunner {
       log.info("deContributeInstance:: de-contribution of instance id {} has finished", instance.getId());
       stats.addRecordsProcessed(1);
       updateStats(stats);
-    }
-  }
-
-  private void deContributeItem(UUID centralServerId, Item item, Statistics stats) {
-    try {
-      stats.addRecordsTotal(1);
-      recordContributionService.deContributeItem(centralServerId, item);
-      stats.addRecordsDeContributed(1);
-      addRecordProcessed();
-    } catch (ServiceSuspendedException | HttpClientErrorException | HttpServerErrorException | InnReachConnectionException ex) {
-      log.error("deContributeItem:: exception occurred on de-contribution of item id {}: {}", item.getId(), ex.getMessage(), ex);
-      throw ex;
-    } catch (Exception ex) {
-      log.error("deContributeItem:: unexpected exception occurred on de-contribution of item id {}: {}", item.getId(), ex.getMessage(), ex);
-      itemExceptionListener.logWriteError(ex, item.getId());
-    } finally {
-      log.info("deContributeItem:: de-contribution of item id {} has finished", item.getId());
-      stats.addRecordsProcessed(1);
-      updateStats(stats);
-    }
-  }
-
-  private void runOngoing(UUID centralServerId, BiConsumer<ContributionJobContext, Statistics> processor) {
-    var contribution = contributionService.createOngoingContribution(centralServerId);
-    var context = ContributionJobContext.builder()
-      .contributionId(contribution.getId())
-      .centralServerId(centralServerId)
-      .tenantId(folioContext.getTenantId())
-      .build();
-
-    var statistics = new Statistics();
-    try {
-      if(getContributionJobContext()==null) {
-        log.info("runOngoing:: setting ongoing contribution context for contributionID: {}", context.getContributionId());
-        beginContributionJobContext(context);
-      }
-      processor.accept(context, statistics);
-      completeContribution(context);
-      endContributionJobContext();
-    } catch (ServiceSuspendedException | HttpClientErrorException | HttpServerErrorException | InnReachConnectionException | InnReachTimeOutException ex) {
-      log.error("runOngoing:: exception occurred on ongoing contribution: {}", context.getContributionId(), ex);
-      throw ex;
-    } catch (Exception ex) {
-      log.error("runOngoing:: unexpected exception occurred on ongoing contribution: ", ex);
-      throw ex;
     }
   }
 

--- a/src/main/java/org/folio/innreach/batch/contribution/service/InitialContributionEventProcessor.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/InitialContributionEventProcessor.java
@@ -84,6 +84,9 @@ public class InitialContributionEventProcessor {
         var contribution = contributionRecord.get(job.getJobId());
         if (contribution != null) {
           logException(job, ex, contribution.getId());
+        } else {
+          log.warn("processInitialContributionEvents:: No contribution record found for jobId {}, exception: {}",
+            job.getJobId(), ex.getMessage());
         }
         updateJobAndContributionStatus(job, FAILED, job.isInstanceContributed());
       }

--- a/src/main/java/org/folio/innreach/domain/listener/KafkaCirculationEventListener.java
+++ b/src/main/java/org/folio/innreach/domain/listener/KafkaCirculationEventListener.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Component;
 
 import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
 import org.folio.innreach.domain.event.DomainEvent;
-import org.folio.innreach.domain.service.ContributionActionService;
 import org.folio.innreach.domain.service.InnReachTransactionActionService;
 import org.folio.innreach.domain.service.impl.BatchDomainEventProcessor;
 import org.folio.innreach.dto.CheckInDTO;
@@ -27,7 +26,6 @@ public class KafkaCirculationEventListener {
 
   private final BatchDomainEventProcessor eventProcessor;
   private final InnReachTransactionActionService transactionActionService;
-  private final ContributionActionService contributionActionService;
 
   @KafkaListener(
     containerFactory = KAFKA_CONTAINER_FACTORY,
@@ -44,11 +42,9 @@ public class KafkaCirculationEventListener {
       var newEntity = event.getData().getNewEntity();
       switch (event.getType()) {
         case CREATED:
-          contributionActionService.handleLoanCreation(newEntity);
           transactionActionService.associateNewLoanWithTransaction(newEntity);
           break;
         case UPDATED:
-          contributionActionService.handleLoanUpdate(newEntity);
           transactionActionService.handleLoanUpdate(newEntity);
           break;
         default:
@@ -71,8 +67,6 @@ public class KafkaCirculationEventListener {
     eventProcessor.process(events, event -> {
       var newEntity = event.getData().getNewEntity();
       var oldEntity = event.getData().getOldEntity();
-
-      contributionActionService.handleRequestChange(newEntity);
 
       if (event.getType() == UPDATED) {
         transactionActionService.handleRequestUpdate(oldEntity, newEntity);

--- a/src/main/java/org/folio/innreach/domain/service/ContributionActionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/ContributionActionService.java
@@ -1,11 +1,9 @@
 package org.folio.innreach.domain.service;
 
-import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
 import org.folio.innreach.domain.entity.OngoingContributionStatus;
 import org.folio.innreach.dto.Holding;
 import org.folio.innreach.dto.Instance;
 import org.folio.innreach.dto.Item;
-import org.folio.innreach.dto.StorageLoanDTO;
 
 public interface ContributionActionService {
 
@@ -20,12 +18,6 @@ public interface ContributionActionService {
   void handleItemUpdate(Item newItem, Item oldItem, OngoingContributionStatus ongoingContributionStatus);
 
   void handleItemDelete(Item deletedItem, OngoingContributionStatus ongoingContributionStatus);
-
-  void handleLoanCreation(StorageLoanDTO loan);
-
-  void handleLoanUpdate(StorageLoanDTO loan);
-
-  void handleRequestChange(RequestDTO request);
 
   void handleHoldingUpdate(Holding holding, OngoingContributionStatus ongoingContributionStatus);
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImpl.java
@@ -7,26 +7,16 @@ import static org.folio.innreach.dto.MappingValidationStatusDTO.VALID;
 import static org.folio.innreach.util.InnReachConstants.INVALID_CENTRAL_SERVER_ID;
 import static org.folio.innreach.util.InnReachConstants.MARC_ERROR_MSG;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.function.Consumer;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.folio.innreach.batch.contribution.service.OngoingContributionStatusService;
 import org.folio.innreach.domain.entity.OngoingContributionStatus;
 import org.folio.innreach.domain.event.DomainEventType;
-import org.folio.innreach.external.exception.InnReachConnectionException;
-import org.folio.innreach.external.exception.ServiceSuspendedException;
-import org.folio.innreach.external.exception.InnReachTimeOutException;
 import org.folio.innreach.util.JsonHelper;
-import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 import org.folio.innreach.batch.contribution.service.ContributionJobRunner;
-import org.folio.innreach.client.InstanceStorageClient;
-import org.folio.innreach.client.ItemStorageClient;
-import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
 import org.folio.innreach.domain.service.ContributionActionService;
 import org.folio.innreach.domain.service.ContributionValidationService;
 import org.folio.innreach.domain.service.HoldingsService;
@@ -34,11 +24,6 @@ import org.folio.innreach.domain.service.InventoryViewService;
 import org.folio.innreach.dto.Holding;
 import org.folio.innreach.dto.Instance;
 import org.folio.innreach.dto.Item;
-import org.folio.innreach.dto.StorageLoanDTO;
-import org.folio.innreach.repository.CentralServerRepository;
-import org.folio.spring.data.OffsetRequest;
-import org.springframework.web.client.HttpClientErrorException;
-import org.springframework.web.client.HttpServerErrorException;
 
 @Log4j2
 @RequiredArgsConstructor
@@ -46,10 +31,7 @@ import org.springframework.web.client.HttpServerErrorException;
 public class ContributionActionServiceImpl implements ContributionActionService {
 
   private final ContributionJobRunner contributionJobRunner;
-  private final CentralServerRepository centralServerRepository;
-  private final ItemStorageClient itemStorageClient;
   private final InventoryViewService inventoryViewService;
-  private final InstanceStorageClient instanceStorageClient;
   private final HoldingsService holdingsService;
   private final ContributionValidationService validationService;
   private final OngoingContributionStatusService ongoingContributionStatusService;
@@ -143,51 +125,6 @@ public class ContributionActionServiceImpl implements ContributionActionService 
   }
 
   @Override
-  public void handleLoanCreation(StorageLoanDTO loan) {
-    log.info("Handling loan creation {}", loan.getId());
-
-    var item = fetchItem(loan.getItemId());
-    var instance = fetchInstanceWithItems(item);
-    if (!isMARCRecord(instance)) {
-      return;
-    }
-
-    handlePerCentralServer(item.getId(), csId -> contributionJobRunner.runItemContribution(csId, instance, item));
-  }
-
-  @Override
-  public void handleLoanUpdate(StorageLoanDTO loan) {
-    log.info("Handling loan update {}", loan.getId());
-
-    var loanAction = loan.getAction();
-
-    if ("renewed".equalsIgnoreCase(loanAction)) {
-      log.info("Triggering ongoing contribution on the renewal of loan {}", loan.getId());
-
-      var item = fetchItem(loan.getItemId());
-      var instance = fetchInstanceWithItems(item);
-      if (!isMARCRecord(instance)) {
-        return;
-      }
-
-      handlePerCentralServer(item.getId(), csId -> contributionJobRunner.runItemContribution(csId, instance, item));
-    }
-  }
-
-  @Override
-  public void handleRequestChange(RequestDTO request) {
-    log.info("Handling request {}", request.getId());
-
-    var item = fetchItem(request.getItemId());
-    var instance = fetchInstanceWithItems(item);
-    if (!isMARCRecord(instance)) {
-      return;
-    }
-
-    handlePerCentralServer(item.getId(), csId -> contributionJobRunner.runItemContribution(csId, instance, item));
-  }
-
-  @Override
   public void handleHoldingUpdate(Holding holding, OngoingContributionStatus ongoingContributionStatus) {
     log.info("Handling holding update {}", holding.getId());
     var instance = fetchInstanceWithItems(holding.getInstanceId());
@@ -247,25 +184,6 @@ public class ContributionActionServiceImpl implements ContributionActionService 
     ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
   }
 
-  private void handlePerCentralServer(UUID recordId, Consumer<UUID> centralServerHandler) {
-    for (var csId : getCentralServerIds()) {
-      try {
-        if (checkCentralServerValid(csId)) {
-          centralServerHandler.accept(csId);
-        } else {
-          log.warn("Central server {} contribution configuration is not valid", csId);
-        }
-      }
-      catch (ServiceSuspendedException | HttpServerErrorException | HttpClientErrorException | InnReachConnectionException |
-             InnReachTimeOutException e) {
-        log.warn("handlePerCentralServer:: exception thrown: {}", e.getMessage());
-        throw e;
-      } catch (Exception e) {
-        log.error("handlePerCentralServer:: Unable to handle record {} for central server {}", recordId, csId, e);
-      }
-    }
-  }
-
   private boolean checkCentralServerValid(UUID centralServerId) {
     return centralServerId != null
       && validationService.getItemTypeMappingStatus(centralServerId) == VALID
@@ -282,11 +200,6 @@ public class ContributionActionServiceImpl implements ContributionActionService 
     return newInstance;
   }
 
-  private List<UUID> getCentralServerIds() {
-    Page<UUID> ids = centralServerRepository.getIds(new OffsetRequest(0, 2000));
-    return ids.getContent();
-  }
-
   private Instance fetchInstanceWithItems(Item item) {
     var holding = fetchHolding(item.getHoldingsRecordId());
     return fetchInstanceWithItems(holding.getInstanceId());
@@ -299,11 +212,6 @@ public class ContributionActionServiceImpl implements ContributionActionService 
   private Holding fetchHolding(UUID holdingId) {
     return holdingsService.find(holdingId)
       .orElseThrow(() -> new IllegalArgumentException("Holding record is not found by id: " + holdingId));
-  }
-
-  private Item fetchItem(UUID itemId) {
-    return itemStorageClient.getItemById(itemId)
-      .orElseThrow(() -> new IllegalArgumentException("Item is not found by id: " + itemId));
   }
 
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/RecordContributionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/RecordContributionServiceImpl.java
@@ -114,11 +114,11 @@ public class RecordContributionServiceImpl implements RecordContributionService 
     try {
       retryTemplate.execute(() -> contributeBibItems(bibId, centralServerId, bibItems));
     } catch (RetryException ex) {
-      log.error("Failed to contribute items for bib {}", bibId, ex);
+      log.error("Failed to contribute {} items for bib {}", items.size(), bibId, ex);
       throw new InnReachContributionRequestException("Contributing items for bib %s has failed".formatted(bibId), ex.getLastException());
     }
 
-    log.info("Finished contributing items of bib {}", bibId);
+    log.info("Finished contributing {} items of bib {}", items.size(), bibId);
     return itemsCount;
   }
 

--- a/src/main/java/org/folio/innreach/external/exception/InnReachTimeOutException.java
+++ b/src/main/java/org/folio/innreach/external/exception/InnReachTimeOutException.java
@@ -1,6 +1,6 @@
 package org.folio.innreach.external.exception;
 
-public class InnReachTimeOutException extends RuntimeException{
+public class InnReachTimeOutException extends RuntimeException {
   public InnReachTimeOutException(String message) {
     super(message);
   }

--- a/src/main/java/org/folio/innreach/scheduler/ContributionJobScheduler.java
+++ b/src/main/java/org/folio/innreach/scheduler/ContributionJobScheduler.java
@@ -55,51 +55,51 @@ public class ContributionJobScheduler {
     initialDelayString = "${contribution.scheduler.initial-delay}")
   public void processInitialContributionEvents() {
     List<String> tenants = loadTenants();
-    log.info("processInitialContributionEvents :: tenantsList {}", tenants);
+    log.debug("processInitialContributionEvents :: tenantsList {}", tenants);
     tenants.forEach(tenant ->
-      tenantScopedExecutionService.runTenantScoped(tenant,
-        () -> {
-          try {
-            long inProgressCount = jobExecutionStatusRepository.getInProgressRecordsCount();
-            if(recordLimit > inProgressCount) {
-              log.info("processInitialContributionEvents:: Fetching new set of records");
-              jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(recordLimit, itemPause)
-                .forEach(eventProcessor::processInitialContributionEvents);
-            } else {
-              log.info("processInitialContributionEvents:: unable to fetch new records, " +
-                "as inProgress count {} is greater than fetchLimit {}", inProgressCount, recordLimit);
+      tenantScopedExecutionService.runTenantScoped(tenant, () -> {
+        try {
+          long inProgressCount = jobExecutionStatusRepository.getInProgressRecordsCount();
+          if(recordLimit > inProgressCount) {
+            var newRecordsToProcess = jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(recordLimit, itemPause);
+            if (!newRecordsToProcess.isEmpty()) {
+              log.info("processInitialContributionEvents:: Fetched new set of {} initial contribution records", newRecordsToProcess.size());
+              newRecordsToProcess.forEach(eventProcessor::processInitialContributionEvents);
             }
-            contributionService.updateStatisticsAndContributionStatus();
-          } catch (Exception ex) {
-            log.warn("Exception caught while processing Initial contribution for tenant {} {} ", tenant, ex.getMessage());
+          } else {
+            log.info("processInitialContributionEvents:: unable to fetch new records, " +
+              "as inProgress count {} is greater than fetchLimit {}", inProgressCount, recordLimit);
           }
+          contributionService.updateStatisticsAndContributionStatus();
+        } catch (Exception ex) {
+          log.warn("Exception caught while processing Initial contribution for tenant {} {} ", tenant, ex.getMessage());
         }
-      ));
+      }));
   }
 
   @Scheduled(fixedDelayString = "${contribution.scheduler.fixed-delay}",
     initialDelayString = "${contribution.scheduler.initial-delay}")
   public void processOngoingContributionEvents() {
     List<String> tenants = loadTenants();
-    log.info("processOngoingContributionEvents :: tenantsList {}", tenants);
+    log.debug("processOngoingContributionEvents :: tenantsList {}", tenants);
     tenants.forEach(tenant ->
-      tenantScopedExecutionService.runTenantScoped(tenant,
-        () -> {
-          try {
-            long inProgressCount = ongoingContributionStatusRepository.getInProgressRecordsCount();
-            if(recordLimit > inProgressCount) {
-              log.info("processOngoingContributionEvents:: Fetching new set of records");
-              ongoingContributionStatusRepository.updateAndFetchOngoingContributionRecordsByStatus(recordLimit)
-                .forEach(ongoingContributionEventProcessor::processOngoingContribution);
-            } else {
-              log.info("processOngoingContributionEvents:: unable to fetch new records, " +
-                "as inProgress count {} is greater than fetchLimit {}", inProgressCount, recordLimit);
+      tenantScopedExecutionService.runTenantScoped(tenant, () -> {
+        try {
+          long inProgressCount = ongoingContributionStatusRepository.getInProgressRecordsCount();
+          if(recordLimit > inProgressCount) {
+            var newRecordsToProcess = ongoingContributionStatusRepository.updateAndFetchOngoingContributionRecordsByStatus(recordLimit);
+            if (!newRecordsToProcess.isEmpty()) {
+              log.info("processOngoingContributionEvents:: Fetched new set of {} ongoing contribution records", newRecordsToProcess.size());
+              newRecordsToProcess.forEach(ongoingContributionEventProcessor::processOngoingContribution);
             }
-          } catch (Exception ex) {
-            log.warn("processOngoingContributionEvents:: Exception caught while processing ongoing contribution for tenant {} {} ", tenant, ex.getMessage());
+          } else {
+            log.info("processOngoingContributionEvents:: unable to fetch new records, " +
+              "as inProgress count {} is greater than fetchLimit {}", inProgressCount, recordLimit);
           }
+        } catch (Exception ex) {
+          log.warn("processOngoingContributionEvents:: Exception caught while processing ongoing contribution for tenant {} {} ", tenant, ex.getMessage());
         }
-      ));
+      }));
   }
 
   private List<String> loadTenants() {

--- a/src/test/java/org/folio/innreach/batch/contribution/service/ContributionJobRunnerTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/ContributionJobRunnerTest.java
@@ -55,10 +55,8 @@ import org.folio.innreach.domain.service.ContributionService;
 import org.folio.innreach.domain.service.ContributionValidationService;
 import org.folio.innreach.domain.service.InventoryViewService;
 import org.folio.innreach.domain.service.RecordContributionService;
-import org.folio.innreach.dto.ContributionDTO;
 import org.folio.innreach.dto.Instance;
 import org.folio.innreach.dto.Item;
-import org.folio.spring.FolioExecutionContext;
 import org.springframework.boot.kafka.autoconfigure.KafkaProperties;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.web.client.HttpClientErrorException;
@@ -93,8 +91,6 @@ class ContributionJobRunnerTest {
   private ContributionJobProperties jobProperties;
   @Mock
   private KafkaProperties kafkaProperties;
-  @Mock
-  private FolioExecutionContext folioContext;
   @Mock
   private ContributionService contributionService;
   @Mock
@@ -325,135 +321,6 @@ class ContributionJobRunnerTest {
     verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, SKIPPING_INELIGIBLE_MSG, ContributionStatus.FAILED);
   }
 
-  @SneakyThrows
-  @Test
-  void runItemContribution() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Instance.class))).thenReturn(true);
-    when(validationService.isEligibleForContribution(any(), any(Item.class))).thenReturn(true);
-    when(contributionService.createOngoingContribution(any())).thenReturn(contribution);
-    when(recordContributor.isContributed(any(), any(), any(Item.class))).thenReturn(true);
-    when(folioContext.getTenantId()).thenReturn(JOB_CONTEXT.getTenantId());
-
-    jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item);
-
-    verify(recordContributor).contributeItems(any(), any(), anyList());
-    verify(recordContributor).contributeInstance(any(), any());
-  }
-
-  @SneakyThrows
-  @Test
-  void runItemContribution_shouldDeContributeIneligible() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Instance.class))).thenReturn(true);
-    when(validationService.isEligibleForContribution(any(), any(Item.class))).thenReturn(false);
-    when(contributionService.createOngoingContribution(any())).thenReturn(contribution);
-    when(recordContributor.isContributed(any(), any(), any(Item.class))).thenReturn(true);
-
-    jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item);
-
-    verify(recordContributor).deContributeItem(any(), any());
-    verify(recordContributor).contributeInstance(any(), any());
-  }
-
-  @SneakyThrows
-  @Test
-  void testDeContributeIneligibleItemException() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Instance.class))).thenReturn(true);
-    when(validationService.isEligibleForContribution(any(), any(Item.class))).thenReturn(false);
-    when(contributionService.createOngoingContribution(any())).thenReturn(contribution);
-    when(recordContributor.isContributed(any(), any(), any(Item.class))).thenReturn(true);
-
-    doThrow(RuntimeException.class).when(recordContributor).deContributeItem(any(), any());
-    jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item);
-    verify(recordContributor).deContributeItem(any(), any());
-    verify(recordContributor).contributeInstance(any(), any());
-
-    doThrow(ServiceSuspendedException.class).when(recordContributor).deContributeItem(any(), any());
-    assertThatThrownBy(() -> jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item))
-      .isInstanceOf(ServiceSuspendedException.class);
-
-    doThrow(HttpClientErrorException.class).when(recordContributor).deContributeItem(any(), any());
-    assertThatThrownBy(() -> jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item))
-      .isInstanceOf(HttpClientErrorException.class);
-
-    doThrow(InnReachConnectionException.class).when(recordContributor).deContributeItem(any(), any());
-    assertThatThrownBy(() -> jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item))
-      .isInstanceOf(InnReachConnectionException.class);
-  }
-
-  @SneakyThrows
-  @Test
-  void testContributionInstanceException() {
-    var item = createItem();
-    var instance = new Instance().source(MARC_RECORD_SOURCE);
-    instance.addItemsItem(item);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Instance.class))).thenReturn(true);
-    when(validationService.isEligibleForContribution(any(), any(Item.class))).thenReturn(false);
-    when(contributionService.createOngoingContribution(any())).thenReturn(contribution);
-    when(recordContributor.isContributed(any(), any(), any(Item.class))).thenReturn(true);
-
-    doThrow(RuntimeException.class).when(recordContributor).contributeInstance(any(), any());
-    jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item);
-    verify(recordContributor).deContributeItem(any(), any());
-    verify(recordContributor).contributeInstance(any(), any());
-
-    doThrow(new InnReachContributionRequestException("error", new ServiceSuspendedException("inn reach server has suspended connections")))
-      .when(recordContributor).contributeInstance(any(), any());
-    assertThatThrownBy(() -> jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item))
-      .isInstanceOf(InnReachContributionRequestException.class)
-      .hasCauseExactlyInstanceOf(ServiceSuspendedException.class);
-
-    doThrow(new InnReachContributionRequestException("error", new InnReachConnectionException("connection issue")))
-      .when(recordContributor).contributeInstance(any(), any());
-    assertThatThrownBy(() -> jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item))
-      .isInstanceOf(InnReachContributionRequestException.class)
-      .hasCauseExactlyInstanceOf(InnReachConnectionException.class);
-
-    doThrow(new InnReachContributionRequestException("error", new InnReachTimeOutException("time out")))
-      .when(recordContributor).contributeInstance(any(), any());
-    assertThatThrownBy(() -> jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item))
-      .isInstanceOf(InnReachContributionRequestException.class)
-      .hasCauseExactlyInstanceOf(InnReachTimeOutException.class);
-
-  }
-
-  @SneakyThrows
-  @Test
-  void runItemContribution_shouldSkipIneligible() {
-    var instance = createInstance();
-    var item = instance.getItems().get(0);
-    var contribution = new ContributionDTO();
-    contribution.setId(UUID.randomUUID());
-
-    when(validationService.isEligibleForContribution(any(), any(Item.class))).thenReturn(false);
-    when(recordContributor.isContributed(any(), any(), any(Item.class))).thenReturn(false);
-
-    jobRunner.runItemContribution(CENTRAL_SERVER_ID, instance, item);
-
-    verify(recordContributor, never()).contributeItems(any(), any(), anyList());
-    verify(contributionService, never()).createOngoingContribution(any());
-  }
-
   @Test
   void startInitialContributionTest() {
     when(factory.createInitialContributionConsumerContainer(any(),any())).thenReturn(initialContributionJobConsumerContainer);
@@ -467,7 +334,7 @@ class ContributionJobRunnerTest {
   }
 
   @Test
-  public void testCancelInitialContribution(){
+  void testCancelInitialContribution(){
     jobRunner.cancelInitialContribution(UUID.randomUUID());
     Assertions.assertNotNull(jobRunner);
   }

--- a/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
+++ b/src/test/java/org/folio/innreach/domain/listener/KafkaCirculationEventListenerApiTest.java
@@ -73,7 +73,6 @@ import org.folio.innreach.domain.event.DomainEvent;
 import org.folio.innreach.domain.event.DomainEventType;
 import org.folio.innreach.domain.event.EntityChangedData;
 import org.folio.innreach.domain.listener.base.BaseKafkaApiTest;
-import org.folio.innreach.domain.service.ContributionActionService;
 import org.folio.innreach.domain.service.impl.BatchDomainEventProcessor;
 import org.folio.innreach.dto.CheckInDTO;
 import org.folio.innreach.dto.ItemStatus;
@@ -124,9 +123,6 @@ class KafkaCirculationEventListenerApiTest extends BaseKafkaApiTest {
 
   @MockitoBean
   private InnReachExternalService innReachExternalService;
-
-  @MockitoBean
-  private ContributionActionService contributionActionService;
 
   @MockitoBean
   private InventoryClient inventoryClient;

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImplTest.java
@@ -15,7 +15,6 @@ import static org.folio.innreach.dto.MappingValidationStatusDTO.INVALID;
 import static org.folio.innreach.dto.MappingValidationStatusDTO.VALID;
 import static org.folio.innreach.fixture.ContributionFixture.createInstance;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -27,17 +26,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.PageImpl;
 
 import org.folio.innreach.batch.contribution.service.ContributionJobRunner;
-import org.folio.innreach.client.InstanceStorageClient;
-import org.folio.innreach.client.ItemStorageClient;
-import org.folio.innreach.domain.dto.folio.circulation.RequestDTO;
 import org.folio.innreach.domain.service.ContributionValidationService;
 import org.folio.innreach.domain.service.HoldingsService;
 import org.folio.innreach.domain.service.InventoryViewService;
-import org.folio.innreach.dto.StorageLoanDTO;
-import org.folio.innreach.repository.CentralServerRepository;
 
 @ExtendWith(MockitoExtension.class)
 class ContributionActionServiceImplTest {
@@ -46,13 +39,7 @@ class ContributionActionServiceImplTest {
   @Mock
   private ContributionJobRunner contributionJobRunner;
   @Mock
-  private CentralServerRepository centralServerRepository;
-  @Mock
-  private ItemStorageClient itemStorageClient;
-  @Mock
   private InventoryViewService inventoryViewService;
-  @Mock
-  private InstanceStorageClient instanceStorageClient;
   @Mock
   private HoldingsService holdingsService;
   @Mock
@@ -63,63 +50,6 @@ class ContributionActionServiceImplTest {
   private OngoingContributionStatusServiceImpl ongoingContributionStatusService;
   @Mock
   private JsonHelper jsonHelper;
-
-  @Test
-  void handleLoanCreation() {
-    var instance = createInstance();
-    var item = instance.getItems().get(0);
-    var holding = instance.getHoldingsRecords().get(0);
-    var loan = new StorageLoanDTO().id(UUID.randomUUID()).itemId(UUID.randomUUID());
-
-    when(centralServerRepository.getIds(any())).thenReturn(new PageImpl<>(List.of(CENTRAL_SERVER_ID)));
-    when(itemStorageClient.getItemById(any())).thenReturn(Optional.of(item));
-    when(inventoryViewService.getInstance(any())).thenReturn(instance);
-    when(holdingsService.find(any())).thenReturn(Optional.of(holding));
-    when(validationService.getItemTypeMappingStatus(any())).thenReturn(VALID);
-    when(validationService.getLocationMappingStatus(any())).thenReturn(VALID);
-
-    service.handleLoanCreation(loan);
-
-    verify(contributionJobRunner).runItemContribution(CENTRAL_SERVER_ID, instance, item);
-  }
-
-  @Test
-  void handleLoanUpdate() {
-    var instance = createInstance();
-    var item = instance.getItems().get(0);
-    var holding = instance.getHoldingsRecords().get(0);
-    var loan = new StorageLoanDTO().id(UUID.randomUUID()).itemId(UUID.randomUUID()).action("renewed");
-
-    when(centralServerRepository.getIds(any())).thenReturn(new PageImpl<>(List.of(CENTRAL_SERVER_ID)));
-    when(itemStorageClient.getItemById(any())).thenReturn(Optional.of(item));
-    when(inventoryViewService.getInstance(any())).thenReturn(instance);
-    when(holdingsService.find(any())).thenReturn(Optional.of(holding));
-    when(validationService.getItemTypeMappingStatus(any())).thenReturn(VALID);
-    when(validationService.getLocationMappingStatus(any())).thenReturn(VALID);
-
-    service.handleLoanUpdate(loan);
-
-    verify(contributionJobRunner).runItemContribution(CENTRAL_SERVER_ID, instance, item);
-  }
-
-  @Test
-  void handleRequestChange() {
-    var instance = createInstance();
-    var item = instance.getItems().get(0);
-    var holding = instance.getHoldingsRecords().get(0);
-    var request = RequestDTO.builder().id(UUID.randomUUID()).itemId(item.getId()).build();
-
-    when(centralServerRepository.getIds(any())).thenReturn(new PageImpl<>(List.of(CENTRAL_SERVER_ID)));
-    when(itemStorageClient.getItemById(any())).thenReturn(Optional.of(item));
-    when(inventoryViewService.getInstance(any())).thenReturn(instance);
-    when(holdingsService.find(any())).thenReturn(Optional.of(holding));
-    when(validationService.getItemTypeMappingStatus(any())).thenReturn(VALID);
-    when(validationService.getLocationMappingStatus(any())).thenReturn(VALID);
-
-    service.handleRequestChange(request);
-
-    verify(contributionJobRunner).runItemContribution(CENTRAL_SERVER_ID, instance, item);
-  }
 
   @Test
   void handleNonMarcItemCreationForOngoingJob() {

--- a/src/test/java/org/folio/innreach/scheduler/ContributionJobSchedulerTest.java
+++ b/src/test/java/org/folio/innreach/scheduler/ContributionJobSchedulerTest.java
@@ -1,0 +1,258 @@
+package org.folio.innreach.scheduler;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import com.google.common.cache.Cache;
+import org.folio.innreach.batch.contribution.service.InitialContributionEventProcessor;
+import org.folio.innreach.batch.contribution.service.OngoingContributionEventProcessor;
+import org.folio.innreach.domain.entity.JobExecutionStatus;
+import org.folio.innreach.domain.entity.OngoingContributionStatus;
+import org.folio.innreach.domain.entity.TenantInfo;
+import org.folio.innreach.domain.service.ContributionService;
+import org.folio.innreach.domain.service.impl.TenantScopedExecutionService;
+import org.folio.innreach.repository.JobExecutionStatusRepository;
+import org.folio.innreach.repository.OngoingContributionStatusRepository;
+import org.folio.innreach.repository.TenantInfoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ContributionJobSchedulerTest {
+
+  private static final String TENANT_ID = "test-tenant";
+  private static final int RECORD_LIMIT = 10;
+  private static final double ITEM_PAUSE = 0.0;
+
+  @Mock
+  private TenantScopedExecutionService tenantScopedExecutionService;
+  @Mock
+  private JobExecutionStatusRepository jobExecutionStatusRepository;
+  @Mock
+  private InitialContributionEventProcessor eventProcessor;
+  @Mock
+  private TenantInfoRepository tenantRepository;
+  @Mock
+  private ContributionService contributionService;
+  @Mock
+  private OngoingContributionStatusRepository ongoingContributionStatusRepository;
+  @Mock
+  private OngoingContributionEventProcessor ongoingContributionEventProcessor;
+  @Mock
+  private Cache<String, List<String>> tenantDetailsCache;
+
+  @InjectMocks
+  private ContributionJobScheduler scheduler;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    setField("recordLimit", RECORD_LIMIT);
+    setField("itemPause", ITEM_PAUSE);
+
+    doAnswer(invocation -> {
+      Runnable runnable = invocation.getArgument(1);
+      runnable.run();
+      return null;
+    }).when(tenantScopedExecutionService).runTenantScoped(any(), any());
+  }
+
+  @Test
+  void postConstruct_updatesInProgressRecordsToReadyForEachTenant() {
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+
+    scheduler.postConstruct();
+
+    verify(jobExecutionStatusRepository).updateInProgressRecordsToReady();
+    verify(ongoingContributionStatusRepository).updateInProgressToReady();
+  }
+
+  @Test
+  void processInitialContributionEvents_processesRecordsWhenBelowLimit() {
+    var job = new JobExecutionStatus();
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(List.of(job));
+
+    scheduler.processInitialContributionEvents();
+
+    verify(eventProcessor).processInitialContributionEvents(job);
+    verify(contributionService).updateStatisticsAndContributionStatus();
+  }
+
+  @Test
+  void processInitialContributionEvents_skipsProcessingWhenInProgressCountExceedsLimit() {
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn((long) RECORD_LIMIT + 1);
+
+    scheduler.processInitialContributionEvents();
+
+    verify(jobExecutionStatusRepository, never()).updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble());
+    verify(eventProcessor, never()).processInitialContributionEvents(any());
+  }
+
+  @Test
+  void processInitialContributionEvents_doesNotCallProcessorWhenNoNewRecords() {
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(Collections.emptyList());
+
+    scheduler.processInitialContributionEvents();
+
+    verify(eventProcessor, never()).processInitialContributionEvents(any());
+    verify(contributionService).updateStatisticsAndContributionStatus();
+  }
+
+  @Test
+  void processInitialContributionEvents_processesEachRecordForMultipleTenants() {
+    var job1 = new JobExecutionStatus();
+    var job2 = new JobExecutionStatus();
+    job1.setId(UUID.randomUUID());
+    job2.setId(UUID.randomUUID());
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID, "other-tenant"));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(List.of(job1))
+      .thenReturn(List.of(job2));
+
+    scheduler.processInitialContributionEvents();
+
+    verify(eventProcessor).processInitialContributionEvents(job1);
+    verify(eventProcessor).processInitialContributionEvents(job2);
+    verify(contributionService, times(2)).updateStatisticsAndContributionStatus();
+  }
+
+  @Test
+  void processInitialContributionEvents_continuesWithOtherTenantsWhenOneFails() {
+    var job = new JobExecutionStatus();
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID, "other-tenant"));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount())
+      .thenThrow(new RuntimeException("DB error"))
+      .thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(List.of(job));
+
+    scheduler.processInitialContributionEvents();
+
+    verify(eventProcessor).processInitialContributionEvents(job);
+  }
+
+  @Test
+  void processOngoingContributionEvents_processesRecordsWhenBelowLimit() {
+    var ongoingJob = new OngoingContributionStatus();
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+    when(ongoingContributionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(ongoingContributionStatusRepository.updateAndFetchOngoingContributionRecordsByStatus(anyInt()))
+      .thenReturn(List.of(ongoingJob));
+
+    scheduler.processOngoingContributionEvents();
+
+    verify(ongoingContributionEventProcessor).processOngoingContribution(ongoingJob);
+  }
+
+  @Test
+  void processOngoingContributionEvents_skipsProcessingWhenInProgressCountExceedsLimit() {
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+    when(ongoingContributionStatusRepository.getInProgressRecordsCount()).thenReturn((long) RECORD_LIMIT + 1);
+
+    scheduler.processOngoingContributionEvents();
+
+    verify(ongoingContributionStatusRepository, never()).updateAndFetchOngoingContributionRecordsByStatus(anyInt());
+    verify(ongoingContributionEventProcessor, never()).processOngoingContribution(any());
+  }
+
+  @Test
+  void processOngoingContributionEvents_doesNotCallProcessorWhenNoNewRecords() {
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID));
+    when(ongoingContributionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(ongoingContributionStatusRepository.updateAndFetchOngoingContributionRecordsByStatus(anyInt()))
+      .thenReturn(Collections.emptyList());
+
+    scheduler.processOngoingContributionEvents();
+
+    verify(ongoingContributionEventProcessor, never()).processOngoingContribution(any());
+  }
+
+  @Test
+  void processOngoingContributionEvents_continuesWithOtherTenantsWhenOneFails() {
+    var ongoingJob = new OngoingContributionStatus();
+    when(tenantDetailsCache.getIfPresent(any())).thenReturn(List.of(TENANT_ID, "other-tenant"));
+    when(ongoingContributionStatusRepository.getInProgressRecordsCount())
+      .thenThrow(new RuntimeException("DB error"))
+      .thenReturn(0L);
+    when(ongoingContributionStatusRepository.updateAndFetchOngoingContributionRecordsByStatus(anyInt()))
+      .thenReturn(List.of(ongoingJob));
+
+    scheduler.processOngoingContributionEvents();
+
+    verify(ongoingContributionEventProcessor).processOngoingContribution(ongoingJob);
+  }
+
+  @Test
+  void loadTenants_returnsCachedTenantsWhenAvailable() {
+    when(tenantDetailsCache.getIfPresent("tenantList")).thenReturn(List.of(TENANT_ID));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(Collections.emptyList());
+
+    scheduler.processInitialContributionEvents();
+    scheduler.processInitialContributionEvents();
+
+    verify(tenantRepository, never()).findAll();
+  }
+
+  @Test
+  void loadTenants_fetchesFromRepositoryWhenCacheIsEmpty() {
+    var tenantInfo = new TenantInfo();
+    tenantInfo.setTenantId(TENANT_ID);
+    when(tenantDetailsCache.getIfPresent("tenantList")).thenReturn(null);
+    when(tenantRepository.findAll()).thenReturn(List.of(tenantInfo));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(Collections.emptyList());
+
+    scheduler.processInitialContributionEvents();
+
+    verify(tenantRepository).findAll();
+    verify(tenantDetailsCache).put("tenantList", List.of(TENANT_ID));
+  }
+
+  @Test
+  void loadTenants_deduplicatesTenantIds() {
+    var tenantInfo1 = new TenantInfo();
+    tenantInfo1.setTenantId(TENANT_ID);
+    var tenantInfo2 = new TenantInfo();
+    tenantInfo2.setTenantId(TENANT_ID);
+    when(tenantDetailsCache.getIfPresent("tenantList")).thenReturn(null);
+    when(tenantRepository.findAll()).thenReturn(List.of(tenantInfo1, tenantInfo2));
+    when(jobExecutionStatusRepository.getInProgressRecordsCount()).thenReturn(0L);
+    when(jobExecutionStatusRepository.updateAndFetchJobExecutionRecordsByStatus(anyInt(), anyDouble()))
+      .thenReturn(Collections.emptyList());
+
+    scheduler.processInitialContributionEvents();
+
+    verify(tenantScopedExecutionService, times(1)).runTenantScoped(any(), any());
+  }
+
+  private void setField(String fieldName, Object value) throws Exception {
+    var field = ContributionJobScheduler.class.getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(scheduler, value);
+  }
+}
+


### PR DESCRIPTION
### Purpose
This change removes the item contribution logic that was triggered by circulation events (loan creation/update and request changes) from `KafkaCirculationEventListener`. 

### Approach
- remove service methods `handleLoanCreation`, `handleLoanUpdate`, `handleRequestChange` from `ContributionActionService` and their call from `KafkaCirculationEventListener`
- adjust tests and all affected places

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-572](https://folio-org.atlassian.net/browse/MODINREACH-572)
