### PR TITLE
MODINREACH-582: Remove introduced sorting from optimized query

### DIFF
--- a/src/main/java/org/folio/innreach/repository/JobExecutionStatusRepository.java
+++ b/src/main/java/org/folio/innreach/repository/JobExecutionStatusRepository.java
@@ -23,7 +23,6 @@ public interface JobExecutionStatusRepository extends JpaRepository<JobExecution
     "AND t.status IN ('READY', 'RETRY') " +
     "AND (t.instance_contributed = false " +
     "OR t.updated_date < current_timestamp - (interval '1 hour') * :itemPause) " +
-    "ORDER BY t.instance_contributed ASC, t.updated_date NULLS FIRST " +
     "FOR UPDATE OF t SKIP LOCKED " +
     "LIMIT :limit) " +
     "UPDATE job_execution_status s " +


### PR DESCRIPTION
### Purpose
In the optimized query, extra sorting/group by was added to logically separate processing of first instance and then it's items contribution, it turned out that this sorting actually makes the query slower than it's previous execution

### Approach
- remove added sorting/group by from the query to fetch batch of claims for the initial contribution

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-582](https://folio-org.atlassian.net/browse/MODINREACH-582)
