### PR TITLE
MODINREACH-574: Fix sending request cancellation notices on handling of cancel request message from Inn-Reach

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 * Add performance and correctness improvements for the initial contribution and ongoing contribution ([MODINREACH-582](https://folio-org.atlassian.net/browse/MODINREACH-582))
 * Add logs to track all Inn-Reach server calls ([MODINREACH-587](https://folio-org.atlassian.net/browse/MODINREACH-587))
 * Separate scheduler job configs for initial and ongoing contributions ([MODINREACH-599](https://folio-org.atlassian.net/browse/MODINREACH-599))
+* Fix sending request cancellation notices on handling of cancel request message from central server ([MODINREACH-574](https://folio-org.atlassian.net/browse/MODINREACH-574)) 
 
 ## v4.0.0 2026-04-17
 

--- a/src/main/java/org/folio/innreach/domain/service/LoanService.java
+++ b/src/main/java/org/folio/innreach/domain/service/LoanService.java
@@ -1,6 +1,5 @@
 package org.folio.innreach.domain.service;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -24,7 +23,7 @@ public interface LoanService extends BasicService<UUID, LoanDTO> {
 
   CheckInResponseDTO checkInItem(InnReachTransaction transaction, UUID servicePointId);
 
-  void claimItemReturned(UUID loanId, Instant itemClaimedReturnedDateTime);
+  void claimItemReturned(UUID loanId, Date itemClaimedReturnedDateTime);
 
   boolean isOpen(LoanDTO loanDTO);
 }

--- a/src/main/java/org/folio/innreach/domain/service/LoanService.java
+++ b/src/main/java/org/folio/innreach/domain/service/LoanService.java
@@ -1,5 +1,6 @@
 package org.folio.innreach.domain.service;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,7 +24,7 @@ public interface LoanService extends BasicService<UUID, LoanDTO> {
 
   CheckInResponseDTO checkInItem(InnReachTransaction transaction, UUID servicePointId);
 
-  void claimItemReturned(UUID loanId, Date itemClaimedReturnedDateTime);
+  void claimItemReturned(UUID loanId, Instant itemClaimedReturnedDateTime);
 
   boolean isOpen(LoanDTO loanDTO);
 }

--- a/src/main/java/org/folio/innreach/domain/service/LoanService.java
+++ b/src/main/java/org/folio/innreach/domain/service/LoanService.java
@@ -1,6 +1,6 @@
 package org.folio.innreach.domain.service;
 
-import java.util.Date;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -17,13 +17,13 @@ public interface LoanService extends BasicService<UUID, LoanDTO> {
 
   LoanDTO renew(RenewByIdDTO renewLoan);
 
-  LoanDTO changeDueDate(LoanDTO loan, Date dueDate);
+  LoanDTO changeDueDate(LoanDTO loan, Instant dueDate);
 
   LoanDTO checkOutItem(InnReachTransaction transaction, UUID servicePointId);
 
   CheckInResponseDTO checkInItem(InnReachTransaction transaction, UUID servicePointId);
 
-  void claimItemReturned(UUID loanId, Date itemClaimedReturnedDateTime);
+  void claimItemReturned(UUID loanId, Instant itemClaimedReturnedDateTime);
 
   boolean isOpen(LoanDTO loanDTO);
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -504,7 +504,7 @@ public class CirculationServiceImpl implements CirculationService {
     Long checkOutTimeDuration = jsonHelper.getCheckoutTimeDurationInMilliseconds(configDataList.getResult());
 
     log.info("deleteVirtualRecords execution started at: [{}] with Checkout Time Duration: [{}]",
-      new Date(), checkOutTimeDuration);
+      Instant.now(), checkOutTimeDuration);
     var task = new FolioAsyncExecutorWrapper(folioExecutionContext,
             () -> virtualRecordService.deleteVirtualRecords(folioItemId, folioHoldingId,
                     folioInstanceId, folioLoanId));
@@ -519,7 +519,7 @@ public class CirculationServiceImpl implements CirculationService {
     var transaction = getTransaction(trackingId, centralCode);
 
     var returnedDateSec = claimsItemReturned.getClaimsReturnedDate();
-    var returnedDate = returnedDateSec != -1 ? Date.from(ofEpochSecond(returnedDateSec)) : new Date();
+    var returnedDate = returnedDateSec != -1 ? ofEpochSecond(returnedDateSec) : Instant.now();
 
     var folioLoanId = transaction.getHold().getFolioLoanId();
     Assert.isTrue(folioLoanId != null, "Loan id is not set for transaction: " + trackingId);

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -109,6 +109,7 @@ import java.util.function.Supplier;
 @Service
 @Transactional
 @RequiredArgsConstructor
+@SuppressWarnings("java:S2143")
 public class CirculationServiceImpl implements CirculationService {
 
   private static final String[] TRANSACTION_HOLD_IGNORE_PROPS_ON_COPY = {
@@ -504,7 +505,7 @@ public class CirculationServiceImpl implements CirculationService {
     Long checkOutTimeDuration = jsonHelper.getCheckoutTimeDurationInMilliseconds(configDataList.getResult());
 
     log.info("deleteVirtualRecords execution started at: [{}] with Checkout Time Duration: [{}]",
-      new Date(), checkOutTimeDuration);
+      Instant.now(), checkOutTimeDuration);
     var task = new FolioAsyncExecutorWrapper(folioExecutionContext,
             () -> virtualRecordService.deleteVirtualRecords(folioItemId, folioHoldingId,
                     folioInstanceId, folioLoanId));

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -251,19 +251,17 @@ public class CirculationServiceImpl implements CirculationService {
     transaction.setState(CANCEL_REQUEST);
 
     var folioItemId = transaction.getHold().getFolioItemId();
-
-    removeItemTransactionInfo(folioItemId)
-      .ifPresent(this::removeHoldingsTransactionInfo);
-
     var folioHoldingId = transaction.getHold().getFolioHoldingId();
     var folioInstanceId = transaction.getHold().getFolioInstanceId();
     var folioLoanId = transaction.getHold().getFolioLoanId();
 
-    virtualRecordService.deleteVirtualRecords(folioItemId,folioHoldingId,folioInstanceId,folioLoanId);
+    executeDeleteVirtualRecordsWithDelay(folioItemId, folioHoldingId, folioInstanceId, folioLoanId);
 
     eventPublisher.publishEvent(CancelRequestEvent.of(transaction,
       INN_REACH_CANCELLATION_REASON_ID, cancelRequest.getReason()));
 
+    removeItemTransactionInfo(folioItemId)
+      .ifPresent(this::removeHoldingsTransactionInfo);
     clearPatronAndItemInfo(transaction.getHold());
 
     log.info("cancelPatronHold:: Cancelled Patron Hold transaction, tracking ID: [{}], central code: [{}]",

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -504,7 +504,7 @@ public class CirculationServiceImpl implements CirculationService {
     Long checkOutTimeDuration = jsonHelper.getCheckoutTimeDurationInMilliseconds(configDataList.getResult());
 
     log.info("deleteVirtualRecords execution started at: [{}] with Checkout Time Duration: [{}]",
-      Instant.now(), checkOutTimeDuration);
+      new Date(), checkOutTimeDuration);
     var task = new FolioAsyncExecutorWrapper(folioExecutionContext,
             () -> virtualRecordService.deleteVirtualRecords(folioItemId, folioHoldingId,
                     folioInstanceId, folioLoanId));
@@ -519,7 +519,7 @@ public class CirculationServiceImpl implements CirculationService {
     var transaction = getTransaction(trackingId, centralCode);
 
     var returnedDateSec = claimsItemReturned.getClaimsReturnedDate();
-    var returnedDate = returnedDateSec != -1 ? ofEpochSecond(returnedDateSec) : Instant.now();
+    var returnedDate = returnedDateSec != -1 ? Date.from(ofEpochSecond(returnedDateSec)) : new Date();
 
     var folioLoanId = transaction.getHold().getFolioLoanId();
     Assert.isTrue(folioLoanId != null, "Loan id is not set for transaction: " + trackingId);

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -96,7 +96,6 @@ import jakarta.persistence.EntityExistsException;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -109,7 +108,6 @@ import java.util.function.Supplier;
 @Service
 @Transactional
 @RequiredArgsConstructor
-@SuppressWarnings("java:S2143")
 public class CirculationServiceImpl implements CirculationService {
 
   private static final String[] TRANSACTION_HOLD_IGNORE_PROPS_ON_COPY = {
@@ -422,23 +420,23 @@ public class CirculationServiceImpl implements CirculationService {
     var transaction = getTransaction(trackingId, centralCode);
     var hold = transaction.getHold();
     var loan = loanService.getById(hold.getFolioLoanId());
-    var existingDueDate = loan.getDueDate();
-    var requestedDueDate = Date.from(ofEpochSecond(renewLoan.getDueDateTime()));
+    var existingDueDate = loan.getDueDate().toInstant();
+    var requestedDueDate = ofEpochSecond(renewLoan.getDueDateTime());
 
     try {
       hold.setDueDateTime(renewLoan.getDueDateTime());
 
       var renewedLoan = renewLoan(hold);
-      var calculatedDueDate = renewedLoan.getDueDate();
+      var calculatedDueDate = renewedLoan.getDueDate().toInstant();
 
-      if (calculatedDueDate.after(requestedDueDate) || calculatedDueDate.equals(requestedDueDate)) {
+      if (!calculatedDueDate.isBefore(requestedDueDate)) {
         transaction.setState(BORROWER_RENEW);
       } else {
         recallRequestToCentralSever(transaction, existingDueDate);
       }
     } catch (Exception e) {
       log.warn("Borrower renew loan failed for trackingId: {}", trackingId, e);
-      if (existingDueDate.before(requestedDueDate)) {
+      if (existingDueDate.isBefore(requestedDueDate)) {
         recallRequestToCentralSever(transaction, existingDueDate);
       } else {
         throw new CirculationException("Failed to renew loan: " + e.getMessage(), e);
@@ -460,10 +458,9 @@ public class CirculationServiceImpl implements CirculationService {
     var calculatedDueDate = renewedLoan.getDueDate().toInstant();
     var requestedDueDate = ofEpochSecond(renewLoan.getDueDateTime());
     if (calculatedDueDate.isAfter(requestedDueDate)) {
-      var changeToDate = Date.from(requestedDueDate);
-      loanService.changeDueDate(renewedLoan, changeToDate);
+      loanService.changeDueDate(renewedLoan, requestedDueDate);
       log.info("ownerRenewLoan:: Loan renewed and then changed to date: {}, trackingId: [{}], centralCode: [{}]",
-        changeToDate, trackingId, centralCode);
+        requestedDueDate, trackingId, centralCode);
       return success();
     }
 
@@ -520,7 +517,7 @@ public class CirculationServiceImpl implements CirculationService {
     var transaction = getTransaction(trackingId, centralCode);
 
     var returnedDateSec = claimsItemReturned.getClaimsReturnedDate();
-    var returnedDate = returnedDateSec != -1 ? Date.from(ofEpochSecond(returnedDateSec)) : new Date();
+    var returnedDate = returnedDateSec != -1 ? ofEpochSecond(returnedDateSec) : Instant.now();
 
     var folioLoanId = transaction.getHold().getFolioLoanId();
     Assert.isTrue(folioLoanId != null, "Loan id is not set for transaction: " + trackingId);
@@ -584,7 +581,7 @@ public class CirculationServiceImpl implements CirculationService {
     return loanService.renew(RenewByIdDTO.of(hold.getFolioItemId(), hold.getFolioPatronId()));
   }
 
-  private void recallRequestToCentralSever(InnReachTransaction transaction, Date existingDueDate) {
+  private void recallRequestToCentralSever(InnReachTransaction transaction, Instant existingDueDate) {
     var trackingId = transaction.getTrackingId();
     var centralCode = transaction.getCentralServerCode();
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/LoanServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/LoanServiceImpl.java
@@ -2,7 +2,6 @@ package org.folio.innreach.domain.service.impl;
 
 import static org.folio.innreach.util.ListUtils.getFirstItem;
 
-import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -104,9 +103,9 @@ public class LoanServiceImpl implements LoanService {
   }
 
   @Override
-  public void claimItemReturned(UUID loanId, Instant itemClaimedReturnedDate) {
+  public void claimItemReturned(UUID loanId, Date itemClaimedReturnedDate) {
     var request = new ClaimItemReturnedRequestDTO()
-      .itemClaimedReturnedDateTime(Date.from(itemClaimedReturnedDate));
+      .itemClaimedReturnedDateTime(itemClaimedReturnedDate);
 
     circulationClient.claimItemReturned(loanId, request);
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/LoanServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/LoanServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.innreach.domain.service.impl;
 
 import static org.folio.innreach.util.ListUtils.getFirstItem;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -103,9 +104,9 @@ public class LoanServiceImpl implements LoanService {
   }
 
   @Override
-  public void claimItemReturned(UUID loanId, Date itemClaimedReturnedDate) {
+  public void claimItemReturned(UUID loanId, Instant itemClaimedReturnedDate) {
     var request = new ClaimItemReturnedRequestDTO()
-      .itemClaimedReturnedDateTime(itemClaimedReturnedDate);
+      .itemClaimedReturnedDateTime(Date.from(itemClaimedReturnedDate));
 
     circulationClient.claimItemReturned(loanId, request);
   }

--- a/src/main/java/org/folio/innreach/domain/service/impl/LoanServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/LoanServiceImpl.java
@@ -2,6 +2,7 @@ package org.folio.innreach.domain.service.impl;
 
 import static org.folio.innreach.util.ListUtils.getFirstItem;
 
+import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
@@ -69,8 +70,8 @@ public class LoanServiceImpl implements LoanService {
   }
 
   @Override
-  public LoanDTO changeDueDate(LoanDTO loan, Date dueDate) {
-    loan.setDueDate(dueDate);
+  public LoanDTO changeDueDate(LoanDTO loan, Instant dueDate) {
+    loan.setDueDate(Date.from(dueDate));
     loan.setAction(DUE_DATE_CHANGED_ACTION);
 
     return update(loan);
@@ -83,7 +84,7 @@ public class LoanServiceImpl implements LoanService {
     var checkIn = new CheckInRequestDTO()
       .servicePointId(servicePointId)
       .itemBarcode(transaction.getHold().getFolioItemBarcode())
-      .checkInDate(new Date());
+      .checkInDate(Date.from(Instant.now()));
 
     return circulationClient.checkInByBarcode(checkIn);
   }
@@ -103,9 +104,9 @@ public class LoanServiceImpl implements LoanService {
   }
 
   @Override
-  public void claimItemReturned(UUID loanId, Date itemClaimedReturnedDate) {
+  public void claimItemReturned(UUID loanId, Instant itemClaimedReturnedDate) {
     var request = new ClaimItemReturnedRequestDTO()
-      .itemClaimedReturnedDateTime(itemClaimedReturnedDate);
+      .itemClaimedReturnedDateTime(Date.from(itemClaimedReturnedDate));
 
     circulationClient.claimItemReturned(loanId, request);
   }

--- a/src/main/java/org/folio/innreach/util/DateHelper.java
+++ b/src/main/java/org/folio/innreach/util/DateHelper.java
@@ -15,6 +15,10 @@ public class DateHelper {
     return (int) toInstantTruncatedToSec(date).getEpochSecond();
   }
 
+  public static int toEpochSec(Instant instant) {
+    return (int) instant.truncatedTo(ChronoUnit.SECONDS).getEpochSecond();
+  }
+
   public static Date addYearToDate(int n) {
     Calendar c = Calendar.getInstance();
     c.setTime(new Date());

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -195,7 +195,7 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
   private PatronHoldService patronHoldService;
   @MockitoBean
   private HoldingsService holdingsService;
-  @MockitoBean
+  @MockitoSpyBean
   private VirtualRecordService virtualRecordService;
   @MockitoBean
   private ConfigurationService configurationService;
@@ -1192,10 +1192,7 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
   void checkTransactionIsNotInStatePatronHoldOrTransfer(InnReachTransaction.TransactionState state) {
     var transactionHoldDTO = createTransactionHoldDTO();
     var transactionBefore = fetchPrePopulatedTransaction();
-    var configurationDto =
-            deserializeFromJsonFile("/configuration/configuration-details-example.json", CirculationSettingDTO.class);
-    when(configurationService.fetchCheckoutSettings()).
-            thenReturn(ResultList.asSinglePage(configurationDto));
+    mockFetchingCirculationSettings();
 
     transactionBefore.setState(state);
     repository.save(transactionBefore);
@@ -1294,8 +1291,8 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     "classpath:db/patron-type-mapping/pre-populate-patron-type-mapping.sql",
   })
   void processCancelRequest() {
+    mockFetchingCirculationSettings();
     doNothing().when(requestService).cancelRequest(anyString(), any(UUID.class), any(UUID.class), anyString());
-    doNothing().when(virtualRecordService).deleteVirtualRecords(any(UUID.class), any(UUID.class), any(UUID.class), any(UUID.class));
     when(userService.getUserById(any(UUID.class))).thenReturn(Optional.of(populateUser()));
 
     var cancelRequestDTO = createCancelRequestDTO();
@@ -1305,14 +1302,14 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
       new HttpEntity<>(cancelRequestDTO, headers), InnReachResponseDTO.class,
       PRE_POPULATED_TRACKING1_ID, PRE_POPULATED_CENTRAL_CODE);
 
-    verify(requestService).cancelRequest(anyString(), any(UUID.class), any(UUID.class), anyString());
-    verify(virtualRecordService).deleteVirtualRecords(any(UUID.class), any(UUID.class), any(UUID.class), any(UUID.class));
-
-    var transactionAfter = fetchPrePopulatedTransaction();
-
-    assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
-    assertEquals(CANCEL_REQUEST, transactionAfter.getState());
-    assertPatronHoldFieldsAreNull((TransactionPatronHold) transactionAfter.getHold());
+    await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() -> {
+      var transactionAfter = fetchPrePopulatedTransaction();
+      assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
+      assertEquals(CANCEL_REQUEST, transactionAfter.getState());
+      verify(requestService).cancelRequest(anyString(), any(UUID.class), any(UUID.class), anyString());
+      verify(virtualRecordService).deleteVirtualRecords(any(), any(), any(), any());
+      assertPatronHoldFieldsAreNull((TransactionPatronHold) transactionAfter.getHold());
+    });
   }
 
   @ParameterizedTest
@@ -1324,11 +1321,8 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
   void testFinalCheckInWithDeleteVirtualRecord(InnReachTransaction.TransactionState state) {
     var transactionHoldDTO = createTransactionHoldDTO();
     var transactionBefore = fetchPrePopulatedTransaction();
-    var configurationDto =
-            deserializeFromJsonFile("/configuration/configuration-details-example.json", CirculationSettingDTO.class);
-    when(configurationService.fetchCheckoutSettings()).
-            thenReturn(ResultList.asSinglePage(configurationDto));
 
+    mockFetchingCirculationSettings();
     transactionBefore.setState(state);
     repository.save(transactionBefore);
 
@@ -1341,8 +1335,18 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
       var transactionAfter = fetchPrePopulatedTransaction();
       assertEquals(HttpStatus.OK, responseEntity.getStatusCode());
       assertEquals(FINAL_CHECKIN, transactionAfter.getState());
+      verify(virtualRecordService).deleteVirtualRecords(any(), any(), any(), any());
       assertPatronHoldFieldsAreNull((TransactionPatronHold) transactionAfter.getHold());
     });
+  }
+
+  private void mockFetchingCirculationSettings() {
+    var configurationDto =
+      deserializeFromJsonFile("/configuration/configuration-details-example.json", CirculationSettingDTO.class);
+    // Override checkoutTimeoutDuration to 0 so the scheduled delete task fires immediately in tests
+    configurationDto.getValue().put("checkoutTimeoutDuration", 0);
+    when(configurationService.fetchCheckoutSettings()).
+      thenReturn(ResultList.asSinglePage(configurationDto));
   }
 
   private void assertPatronHoldFieldsAreNull(TransactionPatronHold hold) {

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -112,6 +112,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+@SuppressWarnings("java:S8692")
 @Sql(
   scripts = {
     "classpath:db/central-server/clear-central-server-tables.sql",

--- a/src/test/java/org/folio/innreach/util/DateHelperTest.java
+++ b/src/test/java/org/folio/innreach/util/DateHelperTest.java
@@ -1,0 +1,121 @@
+package org.folio.innreach.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.junit.jupiter.api.Test;
+
+class DateHelperTest {
+
+  @Test
+  void toInstantTruncatedToSec_returnsInstantWithSecondPrecision() {
+    var date = new Date(1_700_000_000_999L);
+
+    var result = DateHelper.toInstantTruncatedToSec(date);
+
+    assertEquals(Instant.ofEpochSecond(1_700_000_000L), result);
+  }
+
+  @Test
+  void toInstantTruncatedToSec_dateWithExactSecond_returnsUnchangedInstant() {
+    var date = new Date(1_700_000_000_000L);
+
+    var result = DateHelper.toInstantTruncatedToSec(date);
+
+    assertEquals(Instant.ofEpochSecond(1_700_000_000L), result);
+  }
+
+  @Test
+  void toEpochSec_date_returnsEpochSecondsWithMillisTruncated() {
+    var date = new Date(1_700_000_000_999L);
+
+    var result = DateHelper.toEpochSec(date);
+
+    assertEquals(1_700_000_000, result);
+  }
+
+  @Test
+  void toEpochSec_date_epochZero_returnsZero() {
+    var date = new Date(0L);
+
+    var result = DateHelper.toEpochSec(date);
+
+    assertEquals(0, result);
+  }
+
+  @Test
+  void toEpochSec_instant_returnsEpochSecondsWithSubSecondsTruncated() {
+    var instant = Instant.ofEpochSecond(1_700_000_000L, 999_999_999L);
+
+    var result = DateHelper.toEpochSec(instant);
+
+    assertEquals(1_700_000_000, result);
+  }
+
+  @Test
+  void toEpochSec_instant_exactSecond_returnsUnchangedEpochSeconds() {
+    var instant = Instant.ofEpochSecond(1_700_000_000L);
+
+    var result = DateHelper.toEpochSec(instant);
+
+    assertEquals(1_700_000_000, result);
+  }
+
+  @Test
+  void toEpochSec_instant_epochZero_returnsZero() {
+    var result = DateHelper.toEpochSec(Instant.EPOCH);
+
+    assertEquals(0, result);
+  }
+
+  @Test
+  void toEpochSec_dateAndInstant_samePointInTime_returnSameValue() {
+    long epochMillis = 1_700_000_000_500L;
+    var date = new Date(epochMillis);
+    var instant = Instant.ofEpochMilli(epochMillis);
+
+    assertEquals(DateHelper.toEpochSec(date), DateHelper.toEpochSec(instant));
+  }
+
+  @Test
+  void addYearToDate_positiveN_returnsDateInFuture() {
+    var before = new Date();
+
+    var result = DateHelper.addYearToDate(1);
+
+    assertTrue(result.after(before));
+  }
+
+  @Test
+  void addYearToDate_negativeN_returnsDateInPast() {
+    var before = new Date();
+
+    var result = DateHelper.addYearToDate(-1);
+
+    assertTrue(result.before(before));
+  }
+
+  @Test
+  void addYearToDate_zero_returnsApproximatelyNow() {
+    var before = new Date();
+
+    var result = DateHelper.addYearToDate(0);
+
+    var after = new Date();
+    assertTrue(!result.before(before) && !result.after(after));
+  }
+
+  @Test
+  void addYearToDate_multipleYears_addsCorrectNumberOfYears() {
+    var result = DateHelper.addYearToDate(3);
+
+    var threeYearsFromNow = Date.from(Instant.now().plus(3 * 365, ChronoUnit.DAYS));
+    var approxDiff = Math.abs(result.getTime() - threeYearsFromNow.getTime());
+    assertTrue(approxDiff < 2 * 24 * 60 * 60 * 1000L);
+  }
+}
+


### PR DESCRIPTION
### Purpose
Request cancellation notice is not send when handling `cancelrequest` message and the reason is that sending should happen before virtual items (item, holding, instance) are deleted.

### Approach
- schedule deleting virtual items same way as it's done for final check-in

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-574](https://folio-org.atlassian.net/browse/MODINREACH-574)
