### PR TITLE
MODINREACH-575: Fix handling Loan closure for Item Transaction with Recall status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 * Separate scheduler job configs for initial and ongoing contributions ([MODINREACH-599](https://folio-org.atlassian.net/browse/MODINREACH-599))
 * Fix sending request cancellation notices on handling of cancel request message from central server ([MODINREACH-574](https://folio-org.atlassian.net/browse/MODINREACH-574)) 
 * Fix http message converter for response of Fetch Inn-Reach Locations API ([MODINREACH-600](https://folio-org.atlassian.net/browse/MODINREACH-600))  
+* Fix handling Loan closure for Item Transaction with Recall Status ([MODINREACH-575](https://folio-org.atlassian.net/browse/MODINREACH-575))
 
 ## v4.0.0 2026-04-17
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/InnReachTransactionActionServiceImpl.java
@@ -616,7 +616,7 @@ public class InnReachTransactionActionServiceImpl implements InnReachTransaction
   private void updateItemTransactionOnLoanClosure(InnReachTransaction transaction, UUID loanId) {
     log.info("Updating item transaction {} on loan closure {}", transaction.getId(), loanId);
 
-    verifyState(transaction, ITEM_RECEIVED, RECEIVE_UNANNOUNCED, ITEM_SHIPPED, ITEM_IN_TRANSIT, RETURN_UNCIRCULATED, BORROWER_RENEW);
+    verifyState(transaction, ITEM_RECEIVED, RECEIVE_UNANNOUNCED, ITEM_SHIPPED, ITEM_IN_TRANSIT, RETURN_UNCIRCULATED, BORROWER_RENEW, RECALL);
 
     transaction.getHold().setDueDateTime(null);
 


### PR DESCRIPTION
### Purpose
Item Transaction with Recall status is not moved to `FINAL_CHECK_IN` when item is returned back to LENDER/FOLIO and loan is closed (after check-in)

### Approach
Fix handler to accept RECALL transaction as well

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-575](https://folio-org.atlassian.net/browse/MODINREACH-575)
