### PR TITLE
MODINREACH-576: Fix handling IN_TRANSIT message from In-Reach for Transaction with Recall status

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,8 @@
 * Add logs to track all Inn-Reach server calls ([MODINREACH-587](https://folio-org.atlassian.net/browse/MODINREACH-587))
 * Separate scheduler job configs for initial and ongoing contributions ([MODINREACH-599](https://folio-org.atlassian.net/browse/MODINREACH-599))
 * Fix sending request cancellation notices on handling of cancel request message from central server ([MODINREACH-574](https://folio-org.atlassian.net/browse/MODINREACH-574)) 
-* Fix http message converter for response of Fetch Inn-Reach Locations API ([MODINREACH-600](https://folio-org.atlassian.net/browse/MODINREACH-600))  
+* Fix http message converter for response of Fetch Inn-Reach Locations API ([MODINREACH-600](https://folio-org.atlassian.net/browse/MODINREACH-600))
+* Fix handling IN_TRANSIT message from In-Reach for Transaction with Recall status ([MODINREACH-576](https://folio-org.atlassian.net/browse/MODINREACH-576))
 
 ## v4.0.0 2026-04-17
 

--- a/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/CirculationServiceImpl.java
@@ -365,7 +365,7 @@ public class CirculationServiceImpl implements CirculationService {
       trackingId, centralCode, itemInTransitRequest);
     var transaction = getTransaction(trackingId, centralCode);
 
-    verifyState(transaction, ITEM_RECEIVED, RECEIVE_UNANNOUNCED);
+    verifyState(transaction, ITEM_RECEIVED, RECEIVE_UNANNOUNCED, RECALL);
 
     transaction.setState(ITEM_IN_TRANSIT);
 

--- a/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
+++ b/src/test/java/org/folio/innreach/controller/d2ir/InnReachCirculationControllerTest.java
@@ -592,14 +592,15 @@ class InnReachCirculationControllerTest extends BaseControllerTest {
     assertNotEquals(RECEIVE_UNANNOUNCED, transactionUpdated.getState());
   }
 
-  @Test
+  @ParameterizedTest
+  @EnumSource(names = {"ITEM_RECEIVED", "RECEIVE_UNANNOUNCED", "RECALL"})
   @Sql(scripts = {
     "classpath:db/central-server/pre-populate-central-server.sql",
     "classpath:db/inn-reach-transaction/pre-populate-inn-reach-transaction.sql"
   })
-  void processItemInTransit_updateTransactionState() {
+  void processItemInTransit_updateTransactionState(InnReachTransaction.TransactionState state) {
     var transaction = fetchPrePopulatedTransaction();
-    transaction.setState(ITEM_RECEIVED);
+    transaction.setState(state);
     repository.save(transaction);
 
     var transactionHoldDTO = createTransactionHoldDTO();


### PR DESCRIPTION
### Purpose
Transaction with `RECALL` status is not accepting `IN_TRANSIT` message

### Approach
Include `RECALL` to the allowed list of states before shift to `IN_TRANSIT` state

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-576](https://folio-org.atlassian.net/browse/MODINREACH-576)
