### PR TITLE
MODINREACH-512: Handle contribution of Items from a holding moved to new Instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Fix http message converter for response of Fetch Inn-Reach Locations API ([MODINREACH-600](https://folio-org.atlassian.net/browse/MODINREACH-600))  
 * Fix handling Loan closure for Item Transaction with Recall Status ([MODINREACH-575](https://folio-org.atlassian.net/browse/MODINREACH-575))
 * Fix handling IN_TRANSIT message from In-Reach for Transaction with Recall status ([MODINREACH-576](https://folio-org.atlassian.net/browse/MODINREACH-576))
-* Fix contribution of Items from a holding moved to new Instance ([MODINREACH-512](https://folio-org.atlassian.net/browse/MODINREACH-512))
+* Handle contribution of Items from a holding moved to new Instance ([MODINREACH-512](https://folio-org.atlassian.net/browse/MODINREACH-512))
 
 ## v4.0.0 2026-04-17
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Fix http message converter for response of Fetch Inn-Reach Locations API ([MODINREACH-600](https://folio-org.atlassian.net/browse/MODINREACH-600))  
 * Fix handling Loan closure for Item Transaction with Recall Status ([MODINREACH-575](https://folio-org.atlassian.net/browse/MODINREACH-575))
 * Fix handling IN_TRANSIT message from In-Reach for Transaction with Recall status ([MODINREACH-576](https://folio-org.atlassian.net/browse/MODINREACH-576))
+* Fix contribution of Items from a holding moved to new Instance ([MODINREACH-512](https://folio-org.atlassian.net/browse/MODINREACH-512))
 
 ## v4.0.0 2026-04-17
 

--- a/src/main/java/org/folio/innreach/batch/contribution/service/OngoingContributionEventProcessor.java
+++ b/src/main/java/org/folio/innreach/batch/contribution/service/OngoingContributionEventProcessor.java
@@ -100,7 +100,8 @@ public class OngoingContributionEventProcessor {
     switch (ongoingContributionStatus.getDomainEventType()) {
       case UPDATED -> {
         var newEntity = jsonHelper.fromJson(ongoingContributionStatus.getNewEntity(), Holding.class);
-        contributionActionService.handleHoldingUpdate(newEntity, ongoingContributionStatus);
+        var oldEntity = jsonHelper.fromJson(ongoingContributionStatus.getOldEntity(), Holding.class);
+        contributionActionService.handleHoldingUpdate(newEntity, oldEntity, ongoingContributionStatus);
       }
       case DELETED -> {
         var oldEntity = jsonHelper.fromJson(ongoingContributionStatus.getOldEntity(), Holding.class);

--- a/src/main/java/org/folio/innreach/domain/service/ContributionActionService.java
+++ b/src/main/java/org/folio/innreach/domain/service/ContributionActionService.java
@@ -19,7 +19,7 @@ public interface ContributionActionService {
 
   void handleItemDelete(Item deletedItem, OngoingContributionStatus ongoingContributionStatus);
 
-  void handleHoldingUpdate(Holding holding, OngoingContributionStatus ongoingContributionStatus);
+  void handleHoldingUpdate(Holding newHolding, Holding oldHolding, OngoingContributionStatus ongoingContributionStatus);
 
   void handleHoldingDelete(Holding holding, OngoingContributionStatus ongoingContributionStatus);
 }

--- a/src/main/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImpl.java
+++ b/src/main/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImpl.java
@@ -7,6 +7,7 @@ import static org.folio.innreach.dto.MappingValidationStatusDTO.VALID;
 import static org.folio.innreach.util.InnReachConstants.INVALID_CENTRAL_SERVER_ID;
 import static org.folio.innreach.util.InnReachConstants.MARC_ERROR_MSG;
 
+import java.util.Objects;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
@@ -54,7 +55,7 @@ public class ContributionActionServiceImpl implements ContributionActionService 
     var instance = fetchInstanceWithItems(updatedInstance.getId());
 
     var centralServerId = ongoingContributionStatus.getCentralServerId();
-    if (checkCentralServerValid(centralServerId)) {
+    if (isValidCentralServer(centralServerId)) {
       contributionJobRunner.runOngoingInstanceContribution(centralServerId, instance, ongoingContributionStatus);
     } else {
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, INVALID_CENTRAL_SERVER_ID, FAILED);
@@ -81,7 +82,7 @@ public class ContributionActionServiceImpl implements ContributionActionService 
       return;
     }
     var centralServerId = ongoingContributionStatus.getCentralServerId();
-    if (checkCentralServerValid(centralServerId)) {
+    if (isValidCentralServer(centralServerId)) {
       contributionJobRunner.runItemContribution(centralServerId, instance, newItem, ongoingContributionStatus);
     } else {
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, INVALID_CENTRAL_SERVER_ID, FAILED);
@@ -101,7 +102,7 @@ public class ContributionActionServiceImpl implements ContributionActionService 
     var oldInstance = fetchOldInstance(newItem, oldItem, instance);
     boolean itemMoved = !oldInstance.getId().equals(instance.getId());
     var centralServerId = ongoingContributionStatus.getCentralServerId();
-    if (checkCentralServerValid(centralServerId)) {
+    if (isValidCentralServer(centralServerId)) {
       if (itemMoved) {
         contributionJobRunner.runItemMove(centralServerId, instance, oldInstance, newItem, ongoingContributionStatus);
       } else {
@@ -125,39 +126,34 @@ public class ContributionActionServiceImpl implements ContributionActionService 
   }
 
   @Override
-  public void handleHoldingUpdate(Holding holding, OngoingContributionStatus ongoingContributionStatus) {
-    log.info("Handling holding update {}", holding.getId());
-    var instance = fetchInstanceWithItems(holding.getInstanceId());
+  public void handleHoldingUpdate(Holding newHolding, Holding oldHolding, OngoingContributionStatus ongoingContributionStatus) {
+    log.info("Handling holding update {}", newHolding.getId());
+    var instance = fetchInstanceWithItems(newHolding.getInstanceId());
     if (!isMARCRecord(instance)) {
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, MARC_ERROR_MSG, FAILED);
       return;
     }
-    // Filter out the list of item associated with the updated holdings
-    var items = instance.getItems()
-      .stream()
-      .filter(item -> item.getHoldingsRecordId().equals(holding.getId()))
-      .toList();
     var centralServerId = ongoingContributionStatus.getCentralServerId();
-    if (checkCentralServerValid(centralServerId)) {
-      items.forEach(item -> {
-        var newItemJob = createNewOngoingContributionStatus(ongoingContributionStatus, item);
-        newItemJob.setDomainEventType(DomainEventType.UPDATED);
-        contributionJobRunner.runItemContribution(centralServerId, instance, item, newItemJob);
-      });
-      ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
-    } else {
+    if (!isValidCentralServer(centralServerId)) {
       ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, INVALID_CENTRAL_SERVER_ID, FAILED);
+      return;
     }
-  }
+    // Filter out the list of item associated with the updated holdings
+    var items = instance.getItems().stream()
+      .filter(item -> item.getHoldingsRecordId().equals(newHolding.getId()))
+      .toList();
 
-  private OngoingContributionStatus createNewOngoingContributionStatus(OngoingContributionStatus holdingJob, Item item) {
-    var ongoingContribution = new OngoingContributionStatus();
-    ongoingContribution.setParentId(holdingJob.getId());
-    ongoingContribution.setTenant(holdingJob.getTenant());
-    ongoingContribution.setDomainEventName(OngoingContributionStatus.EventName.ITEM);
-    ongoingContribution.setCentralServerId(holdingJob.getCentralServerId());
-    ongoingContribution.setOldEntity(jsonHelper.toJson(item));
-    return ongoingContribution;
+    var itemMoved = !Objects.equals(oldHolding.getInstanceId(), newHolding.getInstanceId());
+    items.forEach(item -> {
+      var newItemJob = createNewOngoingContributionStatus(ongoingContributionStatus, item, DomainEventType.UPDATED);
+      if (itemMoved) {
+        var oldInstance = fetchInstanceWithItems(oldHolding.getInstanceId());
+        contributionJobRunner.runItemMove(centralServerId, instance, oldInstance, item, newItemJob);
+      } else {
+        contributionJobRunner.runItemContribution(centralServerId, instance, item, newItemJob);
+      }
+    });
+    ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
   }
 
   @Override
@@ -177,14 +173,25 @@ public class ContributionActionServiceImpl implements ContributionActionService 
       .filter(item -> item.getHoldingsRecordId().equals(holding.getId()))
       .toList();
     items.forEach(item -> {
-      var newItemJob = createNewOngoingContributionStatus(ongoingContributionStatus, item);
-      newItemJob.setDomainEventType(DomainEventType.DELETED);
+      var newItemJob = createNewOngoingContributionStatus(ongoingContributionStatus, item, DomainEventType.DELETED);
       contributionJobRunner.runItemDeContribution(centralServerId, instance, item, newItemJob);
     });
     ongoingContributionStatusService.updateOngoingContribution(ongoingContributionStatus, PROCESSED);
   }
 
-  private boolean checkCentralServerValid(UUID centralServerId) {
+  private OngoingContributionStatus createNewOngoingContributionStatus(OngoingContributionStatus holdingJob, Item item,
+                                                                       DomainEventType eventType) {
+    var ongoingContribution = new OngoingContributionStatus();
+    ongoingContribution.setParentId(holdingJob.getId());
+    ongoingContribution.setTenant(holdingJob.getTenant());
+    ongoingContribution.setDomainEventName(OngoingContributionStatus.EventName.ITEM);
+    ongoingContribution.setCentralServerId(holdingJob.getCentralServerId());
+    ongoingContribution.setOldEntity(jsonHelper.toJson(item));
+    ongoingContribution.setDomainEventType(eventType);
+    return ongoingContribution;
+  }
+
+  private boolean isValidCentralServer(UUID centralServerId) {
     return centralServerId != null
       && validationService.getItemTypeMappingStatus(centralServerId) == VALID
       && validationService.getLocationMappingStatus(centralServerId) == VALID;

--- a/src/test/java/org/folio/innreach/batch/contribution/service/OngoingContributionEventProcessorTest.java
+++ b/src/test/java/org/folio/innreach/batch/contribution/service/OngoingContributionEventProcessorTest.java
@@ -674,6 +674,7 @@ class OngoingContributionEventProcessorTest extends BaseControllerTest {
 
   @Test
   void testHoldingUpdateEventWithInEligibleItem() {
+    holdingUpdate.getData().getOldEntity().setInstanceId(holdingUpdate.getData().getNewEntity().getInstanceId());
     var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
       .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
     holdings.setId(holdingId);
@@ -697,6 +698,7 @@ class OngoingContributionEventProcessorTest extends BaseControllerTest {
 
   @Test
   void testHoldingUpdateEventWithInEligibleItemButAlreadyContributed() {
+    holdingUpdate.getData().getOldEntity().setInstanceId(holdingUpdate.getData().getNewEntity().getInstanceId());
     var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
       .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
     holdings.setId(holdingId);
@@ -725,6 +727,7 @@ class OngoingContributionEventProcessorTest extends BaseControllerTest {
 
   @Test
   void testHoldingUpdateEventWithEligibleInstanceAndItem() {
+    holdingUpdate.getData().getOldEntity().setInstanceId(holdingUpdate.getData().getNewEntity().getInstanceId());
     var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
       .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
     holdings.setId(holdingId);
@@ -762,6 +765,7 @@ class OngoingContributionEventProcessorTest extends BaseControllerTest {
 
   @Test
   void testHoldingUpdateEventWithEligibleInstanceAndInEligibleItem() {
+    holdingUpdate.getData().getOldEntity().setInstanceId(holdingUpdate.getData().getNewEntity().getInstanceId());
     var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
       .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
     holdings.setId(holdingId);
@@ -885,6 +889,201 @@ class OngoingContributionEventProcessorTest extends BaseControllerTest {
     verify(recordContributionService, times(2)).contributeInstance(any(), any());
     verify(recordContributionService, never()).contributeItems(any(), any(), any());
     verify(recordContributionService, times(2)).deContributeItem(any(), any());
+    verify(recordContributionService, never()).deContributeInstance(any(), any());
+    assertEquals(PROCESSED, ongoingContributionStatus.getStatus());
+    assertNull(ongoingContributionStatus.getError());
+  }
+
+  @Test
+  void testHoldingUpdateEventWithItemMoveAndIneligibleNonContributedItem() {
+    // old and new holdings have different instanceIds (item move scenario)
+    var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
+      .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
+    var newHoldingInstanceId = holdingUpdate.getData().getNewEntity().getInstanceId();
+    var oldHoldingInstanceId = holdingUpdate.getData().getOldEntity().getInstanceId();
+    holdings.setId(holdingId);
+    instanceView.setHoldingsRecords(List.of(holdings));
+    item.setHoldingsRecordId(holdings.getId());
+    instanceView.setItems(List.of(item));
+    when(inventoryViewClient.getInstanceById(newHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(instanceView)));
+    var oldInstanceView = new InventoryViewClient.InstanceView();
+    oldInstanceView.setInstance(createInstance());
+    when(inventoryViewClient.getInstanceById(oldHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(oldInstanceView)));
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Item.class)))
+      .thenReturn(false);
+    when(recordContributionService.isContributed(any(UUID.class), any(Instance.class), any(Item.class)))
+      .thenReturn(false);
+
+    eventProcessor.processOngoingContribution(ongoingContributionStatus);
+
+    await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() ->
+      verify(ongoingContributionStatusRepository, times(3)).save(any()));
+    verify(recordContributionService, never()).contributeInstance(any(), any());
+    verify(recordContributionService, never()).contributeItems(any(), any(), any());
+    verify(recordContributionService, never()).deContributeItem(any(), any());
+    verify(recordContributionService, never()).deContributeInstance(any(), any());
+    assertEquals(PROCESSED, ongoingContributionStatus.getStatus());
+    assertNull(ongoingContributionStatus.getError());
+  }
+
+  @Test
+  void testHoldingUpdateEventWithItemMoveAndContributedItemAndEligibleOldInstance() {
+    var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
+      .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
+    var newHoldingInstanceId = holdingUpdate.getData().getNewEntity().getInstanceId();
+    var oldHoldingInstanceId = holdingUpdate.getData().getOldEntity().getInstanceId();
+    holdings.setId(holdingId);
+    instanceView.setHoldingsRecords(List.of(holdings));
+    item.setHoldingsRecordId(holdings.getId());
+    instanceView.setItems(List.of(item));
+    when(inventoryViewClient.getInstanceById(newHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(instanceView)));
+    var oldInstanceView = new InventoryViewClient.InstanceView();
+    oldInstanceView.setInstance(createInstance());
+    when(inventoryViewClient.getInstanceById(oldHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(oldInstanceView)));
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Item.class)))
+      .thenReturn(true);
+    when(recordContributionService.isContributed(any(UUID.class), any(Instance.class), any(Item.class)))
+      .thenReturn(true);
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Instance.class)))
+      .thenReturn(true);
+    doNothing().when(recordContributionService).deContributeItem(any(), any());
+    doNothing().when(recordContributionService).contributeInstance(any(), any());
+    when(recordContributionService.contributeItems(any(), any(), any())).thenReturn(1);
+
+    eventProcessor.processOngoingContribution(ongoingContributionStatus);
+
+    await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() ->
+      verify(ongoingContributionStatusRepository, times(3)).save(any()));
+    verify(recordContributionService).deContributeItem(any(), any());
+    // contributeInstance called for old instance (re-contribute) + new instance
+    verify(recordContributionService, times(2)).contributeInstance(any(), any());
+    verify(recordContributionService).contributeItems(any(), any(), any());
+    verify(recordContributionService, never()).deContributeInstance(any(), any());
+    assertEquals(PROCESSED, ongoingContributionStatus.getStatus());
+    assertNull(ongoingContributionStatus.getError());
+  }
+
+  @Test
+  void testHoldingUpdateEventWithItemMoveAndContributedItemAndIneligibleOldInstance() {
+    var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
+      .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
+    var newHoldingInstanceId = holdingUpdate.getData().getNewEntity().getInstanceId();
+    var oldHoldingInstanceId = holdingUpdate.getData().getOldEntity().getInstanceId();
+    holdings.setId(holdingId);
+    instanceView.setHoldingsRecords(List.of(holdings));
+    item.setHoldingsRecordId(holdings.getId());
+    instanceView.setItems(List.of(item));
+    when(inventoryViewClient.getInstanceById(newHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(instanceView)));
+    var oldInstanceView = new InventoryViewClient.InstanceView();
+    oldInstanceView.setInstance(createInstance());
+    when(inventoryViewClient.getInstanceById(oldHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(oldInstanceView)));
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Item.class)))
+      .thenReturn(true);
+    when(recordContributionService.isContributed(any(UUID.class), any(Instance.class), any(Item.class)))
+      .thenReturn(true);
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Instance.class)))
+      .thenReturn(false);
+    doNothing().when(recordContributionService).deContributeInstance(any(), any());
+
+    eventProcessor.processOngoingContribution(ongoingContributionStatus);
+
+    await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() ->
+      verify(ongoingContributionStatusRepository, times(3)).save(any()));
+    // old instance is ineligible, so it gets de-contributed
+    verify(recordContributionService).deContributeInstance(any(), any());
+    // new instance is also ineligible, so no contributeInstance or contributeItems
+    verify(recordContributionService, never()).contributeInstance(any(), any());
+    verify(recordContributionService, never()).contributeItems(any(), any(), any());
+    verify(recordContributionService, never()).deContributeItem(any(), any());
+    assertEquals(PROCESSED, ongoingContributionStatus.getStatus());
+    assertNull(ongoingContributionStatus.getError());
+  }
+
+  @Test
+  void testHoldingUpdateEventWithItemMoveAndEligibleItemNotContributedOnOldInstance() {
+    var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
+      .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
+    var newHoldingInstanceId = holdingUpdate.getData().getNewEntity().getInstanceId();
+    var oldHoldingInstanceId = holdingUpdate.getData().getOldEntity().getInstanceId();
+    holdings.setId(holdingId);
+    instanceView.setHoldingsRecords(List.of(holdings));
+    item.setHoldingsRecordId(holdings.getId());
+    instanceView.setItems(List.of(item));
+    when(inventoryViewClient.getInstanceById(newHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(instanceView)));
+    var oldInstanceView = new InventoryViewClient.InstanceView();
+    oldInstanceView.setInstance(createInstance());
+    when(inventoryViewClient.getInstanceById(oldHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(oldInstanceView)));
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Item.class)))
+      .thenReturn(true);
+    when(recordContributionService.isContributed(any(UUID.class), any(Instance.class), any(Item.class)))
+      .thenReturn(false);
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Instance.class)))
+      .thenReturn(true);
+    doNothing().when(recordContributionService).contributeInstance(any(), any());
+    when(recordContributionService.contributeItems(any(), any(), any())).thenReturn(1);
+
+    eventProcessor.processOngoingContribution(ongoingContributionStatus);
+
+    await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() ->
+      verify(ongoingContributionStatusRepository, times(3)).save(any()));
+    // item was not contributed on old instance, so no de-contribute calls for old instance
+    verify(recordContributionService, never()).deContributeItem(any(), any());
+    verify(recordContributionService, never()).deContributeInstance(any(), any());
+    // new instance is eligible, so contribute instance and items
+    verify(recordContributionService).contributeInstance(any(), any());
+    verify(recordContributionService).contributeItems(any(), any(), any());
+    assertEquals(PROCESSED, ongoingContributionStatus.getStatus());
+    assertNull(ongoingContributionStatus.getError());
+  }
+
+  @Test
+  void testHoldingUpdateEventWithItemMoveAndMultipleItems() {
+    var ongoingContributionStatus = saveOngoingContributionStatus(ongoingContributionStatusMapper
+      .convertHoldingToEntity(holdingUpdate), CENTRAL_SERVER_ID);
+    var newHoldingInstanceId = holdingUpdate.getData().getNewEntity().getInstanceId();
+    var oldHoldingInstanceId = holdingUpdate.getData().getOldEntity().getInstanceId();
+    holdings.setId(holdingId);
+    instanceView.setHoldingsRecords(List.of(holdings));
+    var item1 = createItem();
+    item1.setHoldingsRecordId(holdings.getId());
+    item.setHoldingsRecordId(holdings.getId());
+    instanceView.setItems(List.of(item, item1));
+    when(inventoryViewClient.getInstanceById(newHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(instanceView)));
+    var oldInstanceView = new InventoryViewClient.InstanceView();
+    oldInstanceView.setInstance(createInstance());
+    when(inventoryViewClient.getInstanceById(oldHoldingInstanceId))
+      .thenReturn(ResultList.of(1, List.of(oldInstanceView)));
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Item.class)))
+      .thenReturn(true);
+    when(recordContributionService.isContributed(any(UUID.class), any(Instance.class), any(Item.class)))
+      .thenReturn(true);
+    when(validationService.isEligibleForContribution(any(UUID.class), any(Instance.class)))
+      .thenReturn(true);
+    doNothing().when(recordContributionService).deContributeItem(any(), any());
+    doNothing().when(recordContributionService).contributeInstance(any(), any());
+    when(recordContributionService.contributeItems(any(), any(), any())).thenReturn(1);
+
+    eventProcessor.processOngoingContribution(ongoingContributionStatus);
+
+    /*
+     In this test, there are 2 items under a holding being moved to different instance.
+     Each item triggers a separate runItemMove call with its own OngoingContributionStatus entry.
+     */
+    await().atMost(ASYNC_AWAIT_TIMEOUT).untilAsserted(() ->
+      verify(ongoingContributionStatusRepository, times(4)).save(any()));
+    verify(recordContributionService, times(2)).deContributeItem(any(), any());
+    // contributeInstance called: 2x for old instances (re-contribute) + 2x for new instances
+    verify(recordContributionService, times(4)).contributeInstance(any(), any());
+    verify(recordContributionService, times(2)).contributeItems(any(), any(), any());
     verify(recordContributionService, never()).deContributeInstance(any(), any());
     assertEquals(PROCESSED, ongoingContributionStatus.getStatus());
     assertNull(ongoingContributionStatus.getError());

--- a/src/test/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImplTest.java
+++ b/src/test/java/org/folio/innreach/domain/service/impl/ContributionActionServiceImplTest.java
@@ -15,8 +15,10 @@ import static org.folio.innreach.dto.MappingValidationStatusDTO.INVALID;
 import static org.folio.innreach.dto.MappingValidationStatusDTO.VALID;
 import static org.folio.innreach.fixture.ContributionFixture.createInstance;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.folio.innreach.fixture.ContributionFixture;
 
 import org.folio.innreach.batch.contribution.service.OngoingContributionStatusServiceImpl;
 import org.folio.innreach.domain.entity.OngoingContributionStatus;
@@ -226,7 +228,7 @@ class ContributionActionServiceImplTest {
     ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
     when(inventoryViewService.getInstance(any())).thenReturn(instance);
 
-    service.handleHoldingUpdate(holding, ongoingJob);
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
 
     verify(contributionJobRunner, never()).runItemContribution(any(), any(), any(), any());
     verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, MARC_ERROR_MSG, FAILED);
@@ -242,7 +244,7 @@ class ContributionActionServiceImplTest {
     when(inventoryViewService.getInstance(any())).thenReturn(instance);
     when(validationService.getItemTypeMappingStatus(any())).thenReturn(INVALID);
 
-    service.handleHoldingUpdate(holding, ongoingJob);
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
 
     verify(contributionJobRunner, never()).runItemContribution(any(), any(), any(), any());
     verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, INVALID_CENTRAL_SERVER_ID, FAILED);
@@ -261,7 +263,7 @@ class ContributionActionServiceImplTest {
     when(validationService.getItemTypeMappingStatus(any())).thenReturn(VALID);
     when(validationService.getLocationMappingStatus(any())).thenReturn(VALID);
 
-    service.handleHoldingUpdate(holding, ongoingJob);
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
 
     verify(contributionJobRunner).runItemContribution(eq(CENTRAL_SERVER_ID), eq(instance), eq(item), any());
     verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, PROCESSED);
@@ -350,6 +352,147 @@ class ContributionActionServiceImplTest {
     service.handleInstanceDelete(instance, ongoingJob);
 
     verify(contributionJobRunner).runOngoingInstanceDeContribution(CENTRAL_SERVER_ID, instance, ongoingJob);
+  }
+
+  @Test
+  void handleHoldingUpdateWithNullCentralServerId() {
+    var instance = createInstance();
+    var holding = instance.getHoldingsRecords().get(0);
+    instance.getItems().get(0).setHoldingsRecordId(holding.getId());
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(null);
+    when(inventoryViewService.getInstance(any())).thenReturn(instance);
+
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
+
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, INVALID_CENTRAL_SERVER_ID, FAILED);
+    verifyNoInteractions(contributionJobRunner);
+  }
+
+  @Test
+  void handleHoldingUpdateWithInvalidLocationMapping() {
+    var instance = createInstance();
+    var holding = instance.getHoldingsRecords().get(0);
+    instance.getItems().get(0).setHoldingsRecordId(holding.getId());
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
+    when(inventoryViewService.getInstance(any())).thenReturn(instance);
+    when(validationService.getItemTypeMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+    when(validationService.getLocationMappingStatus(CENTRAL_SERVER_ID)).thenReturn(INVALID);
+
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
+
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, INVALID_CENTRAL_SERVER_ID, FAILED);
+    verifyNoInteractions(contributionJobRunner);
+  }
+
+  @Test
+  void handleHoldingUpdateWithNoMatchingItems() {
+    var instance = createInstance();
+    var holding = instance.getHoldingsRecords().get(0);
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
+    when(inventoryViewService.getInstance(any())).thenReturn(instance);
+    when(validationService.getItemTypeMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+    when(validationService.getLocationMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
+
+    verifyNoInteractions(contributionJobRunner);
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, PROCESSED);
+  }
+
+  @Test
+  void handleHoldingUpdateWithItemMoveToDifferentInstance() {
+    var newInstance = createInstance();
+    var oldInstance = createInstance();
+    var newHolding = newInstance.getHoldingsRecords().get(0);
+    var oldHolding = oldInstance.getHoldingsRecords().get(0);
+    newHolding.setInstanceId(newInstance.getId());
+    oldHolding.setInstanceId(oldInstance.getId());
+    var item = newInstance.getItems().get(0);
+    item.setHoldingsRecordId(newHolding.getId());
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
+    when(inventoryViewService.getInstance(newHolding.getInstanceId())).thenReturn(newInstance);
+    when(inventoryViewService.getInstance(oldHolding.getInstanceId())).thenReturn(oldInstance);
+    when(validationService.getItemTypeMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+    when(validationService.getLocationMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+
+    service.handleHoldingUpdate(newHolding, oldHolding, ongoingJob);
+
+    verify(contributionJobRunner).runItemMove(eq(CENTRAL_SERVER_ID), eq(newInstance), eq(oldInstance), eq(item), any());
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, PROCESSED);
+  }
+
+  @Test
+  void handleHoldingUpdateWithMultipleMatchingItems() {
+    var instance = createInstance();
+    var holding = instance.getHoldingsRecords().get(0);
+    var item1 = instance.getItems().get(0);
+    item1.setHoldingsRecordId(holding.getId());
+    var item2 = ContributionFixture.createItem();
+    item2.setHoldingsRecordId(holding.getId());
+    instance.setItems(List.of(item1, item2));
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
+    when(inventoryViewService.getInstance(any())).thenReturn(instance);
+    when(validationService.getItemTypeMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+    when(validationService.getLocationMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+
+    service.handleHoldingUpdate(holding, holding, ongoingJob);
+
+    verify(contributionJobRunner).runItemContribution(eq(CENTRAL_SERVER_ID), eq(instance), eq(item1), any());
+    verify(contributionJobRunner).runItemContribution(eq(CENTRAL_SERVER_ID), eq(instance), eq(item2), any());
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, PROCESSED);
+  }
+
+  @Test
+  void handleHoldingUpdateWithMultipleItemsMovedToDifferentInstance() {
+    var newInstance = createInstance();
+    var oldInstance = createInstance();
+    var newHolding = newInstance.getHoldingsRecords().get(0);
+    var oldHolding = oldInstance.getHoldingsRecords().get(0);
+    newHolding.setInstanceId(newInstance.getId());
+    oldHolding.setInstanceId(oldInstance.getId());
+    var item1 = newInstance.getItems().get(0);
+    item1.setHoldingsRecordId(newHolding.getId());
+    var item2 = ContributionFixture.createItem();
+    item2.setHoldingsRecordId(newHolding.getId());
+    newInstance.setItems(List.of(item1, item2));
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
+    when(inventoryViewService.getInstance(newHolding.getInstanceId())).thenReturn(newInstance);
+    when(inventoryViewService.getInstance(oldHolding.getInstanceId())).thenReturn(oldInstance);
+    when(validationService.getItemTypeMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+    when(validationService.getLocationMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+
+    service.handleHoldingUpdate(newHolding, oldHolding, ongoingJob);
+
+    verify(contributionJobRunner).runItemMove(eq(CENTRAL_SERVER_ID), eq(newInstance), eq(oldInstance), eq(item1), any());
+    verify(contributionJobRunner).runItemMove(eq(CENTRAL_SERVER_ID), eq(newInstance), eq(oldInstance), eq(item2), any());
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, PROCESSED);
+  }
+
+  @Test
+  void handleHoldingUpdateWithSameInstanceId() {
+    var instance = createInstance();
+    var holding = instance.getHoldingsRecords().get(0);
+    var item = instance.getItems().get(0);
+    item.setHoldingsRecordId(holding.getId());
+    var oldHolding = ContributionFixture.createHolding();
+    oldHolding.setInstanceId(holding.getInstanceId());
+    var ongoingJob = new OngoingContributionStatus();
+    ongoingJob.setCentralServerId(CENTRAL_SERVER_ID);
+    when(inventoryViewService.getInstance(any())).thenReturn(instance);
+    when(validationService.getItemTypeMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+    when(validationService.getLocationMappingStatus(CENTRAL_SERVER_ID)).thenReturn(VALID);
+
+    service.handleHoldingUpdate(holding, oldHolding, ongoingJob);
+
+    verify(contributionJobRunner).runItemContribution(eq(CENTRAL_SERVER_ID), eq(instance), eq(item), any());
+    verify(contributionJobRunner, never()).runItemMove(any(), any(), any(), any(), any());
+    verify(ongoingContributionStatusService).updateOngoingContribution(ongoingJob, PROCESSED);
   }
 
 }


### PR DESCRIPTION
### Purpose
Handle Item Contribution when Holding is moved to a news instance

### Approach
- handle Holding Updated event and in case associated Instance IDs differ run logic of item contribution for Item Move case

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINREACH-512](https://folio-org.atlassian.net/browse/MODINREACH-512)